### PR TITLE
Adding documentation and license to FindComputeCpp

### DIFF
--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -1,6 +1,23 @@
 #.rst:
 # FindComputeCpp
 #---------------
+#
+#   Copyright 2016 Codeplay Software Ltd.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use these files except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   For your convenience, a copy of the License has been included in this
+#   repository.
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 
 #########################
 #  FindComputeCpp.cmake  
@@ -8,6 +25,10 @@
 #
 #  Tools for finding and building with ComputeCpp.
 #
+#  User must define COMPUTECPP_SDK_ROOT pointing to the ComputeCpp installation.
+#  
+#  Latest version of this file can be found at:
+#    https://github.com/codeplaysoftware/computecpp-sdk
 
 # Require CMake version 3.2.2 or higher
 cmake_minimum_required(VERSION 3.2.2)

--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -10,8 +10,6 @@
 #
 #       http://www.apache.org/licenses/LICENSE-2.0
 #
-#   For your convenience, a copy of the License has been included in this
-#   repository.
 #
 #   Unless required by applicable law or agreed to in writing, software
 #   distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +23,8 @@
 #
 #  Tools for finding and building with ComputeCpp.
 #
-#  User must define COMPUTECPP_SDK_ROOT pointing to the ComputeCpp installation.
+#  User must define COMPUTECPP_PACKAGE_ROOT_DIR pointing to the ComputeCpp 
+#   installation.
 #  
 #  Latest version of this file can be found at:
 #    https://github.com/codeplaysoftware/computecpp-sdk


### PR DESCRIPTION
This patch adds some licensing and documentation information for the
FindComputeCpp module in order to easily re-distribute the FindComputeCpp file
without the rest of the SDK.