### PR TITLE
CMake target building from multiple TUs

### DIFF
--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -163,8 +163,11 @@ endif()
 #  targetName : Name of the target.
 #  sourceFile : Source file to be compiled.
 #  binaryDir : Intermediate directory to output the integration header.
+#  fileCounter : Counter included in name of custom target. Different counter
+#       values prevent duplicated names of custom target when source files with the same name,
+#       but located in different directories, are used for the same target.
 #
-function(__build_spir targetName sourceFile binaryDir)
+function(__build_spir targetName sourceFile binaryDir fileCounter)
   
   # Retrieve source file name.
   get_filename_component(sourceFileName ${sourceFile} NAME)
@@ -203,11 +206,14 @@ function(__build_spir targetName sourceFile binaryDir)
     WORKING_DIRECTORY ${binaryDir}
   COMMENT "Building ComputeCpp integration header file ${outputSyclFile}")
 
+  # Name: (user-defined name)_(source file)_(counter for same source file name)_integration_header
+  set(headerTargetName ${targetName}_${sourceFileName}_${fileCounter}_integration_header)
+  message(${headerTargetName})
   # Add a custom target for the generated integration header
-  add_custom_target(${targetName}_integration_header DEPENDS ${outputSyclFile})
+  add_custom_target(${headerTargetName} DEPENDS ${outputSyclFile})
 
   # Add a dependency on the integration header
-  add_dependencies(${targetName} ${targetName}_integration_header)
+  add_dependencies(${targetName} ${headerTargetName})
 
   # Force inclusion of the integration header for the host compiler
   set(compileFlags -include ${outputSyclFile} "-Wall")
@@ -232,13 +238,18 @@ endfunction()
 #  target and sets a dependancy on that new command.
 #
 #  targetName : Name of the target to add a SYCL to.
-#  sourceFile : Source file to be compiled for SYCL.
 #  binaryDir : Intermediate directory to output the integration header.
+#  sourceFiles : Source files to be compiled for SYCL.
 #
-function(add_sycl_to_target targetName sourceFile binaryDir)
+function(add_sycl_to_target targetName binaryDir sourceFiles)
 
+  set(sourceFiles ${sourceFiles} ${ARGN})
+  set(fileCounter 0)
   # Add custom target to run compute++ and generate the integration header
-  __build_spir(${targetName} ${sourceFile} ${binaryDir})
+  foreach(sourceFile ${sourceFiles})
+    __build_spir(${targetName} ${sourceFile} ${binaryDir} ${fileCounter})
+    MATH(EXPR fileCounter "${fileCounter} + 1")
+  endforeach()
 
   # Link with the ComputeCpp runtime library
   target_link_libraries(${targetName} PUBLIC ${COMPUTECPP_RUNTIME_LIBRARY}

--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -208,7 +208,7 @@ function(__build_spir targetName sourceFile binaryDir fileCounter)
 
   # Name: (user-defined name)_(source file)_(counter for same source file name)_integration_header
   set(headerTargetName ${targetName}_${sourceFileName}_${fileCounter}_integration_header)
-  message(${headerTargetName})
+  
   # Add a custom target for the generated integration header
   add_custom_target(${headerTargetName} DEPENDS ${outputSyclFile})
 

--- a/samples/accessors/CMakeLists.txt
+++ b/samples/accessors/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(${COMPUTECPP_INCLUDE_DIRECTORY})
 add_executable(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 target_compile_options(${SOURCE_NAME} PUBLIC ${HOST_COMPILER_OPTIONS})
 
-add_sycl_to_target(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp 
-                    ${CMAKE_CURRENT_BINARY_DIR})
+add_sycl_to_target(${SOURCE_NAME}  ${CMAKE_CURRENT_BINARY_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 
 add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})

--- a/samples/async_handler/CMakeLists.txt
+++ b/samples/async_handler/CMakeLists.txt
@@ -5,6 +5,6 @@ include_directories(${COMPUTECPP_INCLUDE_DIRECTORY})
 add_executable(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp  )
 target_compile_options(${SOURCE_NAME} PUBLIC ${HOST_COMPILER_OPTIONS})
 
-add_sycl_to_target(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp 
-                    ${CMAKE_CURRENT_BINARY_DIR})
+add_sycl_to_target(${SOURCE_NAME}  ${CMAKE_CURRENT_BINARY_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})

--- a/samples/custom_device_selector/CMakeLists.txt
+++ b/samples/custom_device_selector/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(${COMPUTECPP_INCLUDE_DIRECTORY})
 add_executable(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp  )
 target_compile_options(${SOURCE_NAME} PUBLIC ${HOST_COMPILER_OPTIONS})
 
-add_sycl_to_target(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp 
-                    ${CMAKE_CURRENT_BINARY_DIR})
+add_sycl_to_target(${SOURCE_NAME}  ${CMAKE_CURRENT_BINARY_DIR}
+                   ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 
 add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})

--- a/samples/example_sycl_application/CMakeLists.txt
+++ b/samples/example_sycl_application/CMakeLists.txt
@@ -4,7 +4,7 @@ include_directories(${COMPUTECPP_INCLUDE_DIRECTORY})
 add_executable(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp  )
 target_compile_options(${SOURCE_NAME} PUBLIC ${HOST_COMPILER_OPTIONS})
 
-add_sycl_to_target(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp 
-                    ${CMAKE_CURRENT_BINARY_DIR})
+add_sycl_to_target(${SOURCE_NAME}  ${CMAKE_CURRENT_BINARY_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 
 add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})

--- a/samples/gaussian_blur/CMakeLists.txt
+++ b/samples/gaussian_blur/CMakeLists.txt
@@ -7,8 +7,8 @@ target_compile_options(
   ${SOURCE_NAME}
   PUBLIC ${HOST_COMPILER_OPTIONS} -Wno-unused-but-set-variable)
 
-add_sycl_to_target(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp
-                    ${CMAKE_CURRENT_BINARY_DIR})
+add_sycl_to_target(${SOURCE_NAME} ${CMAKE_CURRENT_BINARY_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 
 # Copy the image Lenna.png into the binary directory. As there are no
 # configuration directories on multi configuration generators (i.e. MSVC) if you

--- a/samples/hello_world/CMakeLists.txt
+++ b/samples/hello_world/CMakeLists.txt
@@ -5,6 +5,6 @@ include_directories(${COMPUTECPP_INCLUDE_DIRECTORY})
 add_executable(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp  )
 target_compile_options(${SOURCE_NAME} PUBLIC ${HOST_COMPILER_OPTIONS})
 
-add_sycl_to_target(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp 
-                    ${CMAKE_CURRENT_BINARY_DIR})
+add_sycl_to_target(${SOURCE_NAME}  ${CMAKE_CURRENT_BINARY_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})

--- a/samples/images/CMakeLists.txt
+++ b/samples/images/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(${COMPUTECPP_INCLUDE_DIRECTORY})
 add_executable(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp  )
 target_compile_options(${SOURCE_NAME} PUBLIC ${HOST_COMPILER_OPTIONS})
 
-add_sycl_to_target(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp 
-                    ${CMAKE_CURRENT_BINARY_DIR})
+add_sycl_to_target(${SOURCE_NAME}  ${CMAKE_CURRENT_BINARY_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 
 add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})

--- a/samples/matrix_multiply/CMakeLists.txt
+++ b/samples/matrix_multiply/CMakeLists.txt
@@ -8,8 +8,8 @@ target_compile_options(
   PUBLIC ${HOST_COMPILER_OPTIONS} -Wno-unknown-pragmas
   )
 
-add_sycl_to_target(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp 
-                    ${CMAKE_CURRENT_BINARY_DIR})
+add_sycl_to_target(${SOURCE_NAME}  ${CMAKE_CURRENT_BINARY_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 
 add_test(NAME ${SOURCE_NAME}_omp COMMAND ${SOURCE_NAME} 64 omp)
 add_test(NAME ${SOURCE_NAME}_sycl COMMAND ${SOURCE_NAME} 64 sycl)

--- a/samples/opencl_c_interop/CMakeLists.txt
+++ b/samples/opencl_c_interop/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(${COMPUTECPP_INCLUDE_DIRECTORY})
 add_executable(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp  )
 target_compile_options(${SOURCE_NAME} PUBLIC ${HOST_COMPILER_OPTIONS})
 
-add_sycl_to_target(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp 
-                    ${CMAKE_CURRENT_BINARY_DIR})
+add_sycl_to_target(${SOURCE_NAME}  ${CMAKE_CURRENT_BINARY_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 
 add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})

--- a/samples/parallel_for/CMakeLists.txt
+++ b/samples/parallel_for/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(${COMPUTECPP_INCLUDE_DIRECTORY})
 add_executable(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 target_compile_options(${SOURCE_NAME} PUBLIC ${HOST_COMPILER_OPTIONS})
 
-add_sycl_to_target(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp 
-                    ${CMAKE_CURRENT_BINARY_DIR})
+add_sycl_to_target(${SOURCE_NAME}  ${CMAKE_CURRENT_BINARY_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 
 add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})

--- a/samples/reduction/CMakeLists.txt
+++ b/samples/reduction/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(${COMPUTECPP_INCLUDE_DIRECTORY})
 add_executable(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 target_compile_options(${SOURCE_NAME} PUBLIC ${HOST_COMPILER_OPTIONS})
 
-add_sycl_to_target(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp 
-                    ${CMAKE_CURRENT_BINARY_DIR})
+add_sycl_to_target(${SOURCE_NAME}  ${CMAKE_CURRENT_BINARY_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 
 add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})

--- a/samples/simple_example_of_vectors/CMakeLists.txt
+++ b/samples/simple_example_of_vectors/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(${COMPUTECPP_INCLUDE_DIRECTORY})
 add_executable(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 target_compile_options(${SOURCE_NAME} PUBLIC ${HOST_COMPILER_OPTIONS})
 
-add_sycl_to_target(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp 
-                    ${CMAKE_CURRENT_BINARY_DIR})
+add_sycl_to_target(${SOURCE_NAME}  ${CMAKE_CURRENT_BINARY_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 
 add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})

--- a/samples/simple_local_barrier/CMakeLists.txt
+++ b/samples/simple_local_barrier/CMakeLists.txt
@@ -5,6 +5,6 @@ include_directories(${COMPUTECPP_INCLUDE_DIRECTORY})
 add_executable(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 target_compile_options(${SOURCE_NAME} PUBLIC ${HOST_COMPILER_OPTIONS})
 
-add_sycl_to_target(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp 
-                    ${CMAKE_CURRENT_BINARY_DIR})
+add_sycl_to_target(${SOURCE_NAME}  ${CMAKE_CURRENT_BINARY_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})

--- a/samples/simple_private_memory/CMakeLists.txt
+++ b/samples/simple_private_memory/CMakeLists.txt
@@ -5,6 +5,6 @@ include_directories(${COMPUTECPP_INCLUDE_DIRECTORY})
 add_executable(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 target_compile_options(${SOURCE_NAME} PUBLIC ${HOST_COMPILER_OPTIONS})
 
-add_sycl_to_target(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp 
-                    ${CMAKE_CURRENT_BINARY_DIR})
+add_sycl_to_target(${SOURCE_NAME}  ${CMAKE_CURRENT_BINARY_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})

--- a/samples/simple_vector_add/CMakeLists.txt
+++ b/samples/simple_vector_add/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(${COMPUTECPP_INCLUDE_DIRECTORY})
 add_executable(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 target_compile_options(${SOURCE_NAME} PUBLIC ${HOST_COMPILER_OPTIONS})
 
-add_sycl_to_target(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp 
-                    ${CMAKE_CURRENT_BINARY_DIR})
+add_sycl_to_target(${SOURCE_NAME}  ${CMAKE_CURRENT_BINARY_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 
 add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})

--- a/samples/smart_pointer/CMakeLists.txt
+++ b/samples/smart_pointer/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(${COMPUTECPP_INCLUDE_DIRECTORY})
 add_executable(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 target_compile_options(${SOURCE_NAME} PUBLIC ${HOST_COMPILER_OPTIONS})
 
-add_sycl_to_target(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp 
-                    ${CMAKE_CURRENT_BINARY_DIR})
+add_sycl_to_target(${SOURCE_NAME}  ${CMAKE_CURRENT_BINARY_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 
 add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})

--- a/samples/template_functor/CMakeLists.txt
+++ b/samples/template_functor/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(${COMPUTECPP_INCLUDE_DIRECTORY})
 add_executable(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 target_compile_options(${SOURCE_NAME} PUBLIC ${HOST_COMPILER_OPTIONS})
 
-add_sycl_to_target(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp 
-                    ${CMAKE_CURRENT_BINARY_DIR})
+add_sycl_to_target(${SOURCE_NAME}  ${CMAKE_CURRENT_BINARY_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 
 add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})

--- a/samples/using_functors/CMakeLists.txt
+++ b/samples/using_functors/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(${COMPUTECPP_INCLUDE_DIRECTORY})
 add_executable(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 target_compile_options(${SOURCE_NAME} PUBLIC ${HOST_COMPILER_OPTIONS})
 
-add_sycl_to_target(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp 
-                    ${CMAKE_CURRENT_BINARY_DIR})
+add_sycl_to_target(${SOURCE_NAME}  ${CMAKE_CURRENT_BINARY_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp)
 
 add_test(NAME ${SOURCE_NAME} COMMAND ${SOURCE_NAME})


### PR DESCRIPTION
Fix #15
Supporting targets with multiple source files is a must-have feature for many projects.