### PR TITLE
Add missing headers preventing compilation on Ubuntu 16.10

### DIFF
--- a/samples/opencl_c_interop/opencl_c_interop.cpp
+++ b/samples/opencl_c_interop/opencl_c_interop.cpp
@@ -28,6 +28,7 @@
 #include <CL/sycl.hpp>
 
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 
 using namespace cl::sycl;

--- a/samples/simple_local_barrier/simple_local_barrier.cpp
+++ b/samples/simple_local_barrier/simple_local_barrier.cpp
@@ -29,6 +29,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <numeric>
 
 using namespace cl::sycl;
 


### PR DESCRIPTION
`std::pow` and `std::iota` need to be declared before use