### PR TITLE
Improve sample documentation and ignore html/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,5 @@ build/
 
 # HTML/PDF output from documentation
 html/
-.html
-.pdf
+*.html
+*.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ build/
 *.swp
 
 # HTML/PDF output from documentation
+html/
 .html
 .pdf

--- a/samples/hello_world/hello_world.cpp
+++ b/samples/hello_world/hello_world.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *
- *  Copyright (C) 2016 Codeplay Software Limited
+ *  Copyright (C) 2016-2017 Codeplay Software Limited
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -27,28 +27,47 @@
 
 #include <CL/sycl.hpp>
 
-using namespace cl::sycl;
+#include <iostream>
 
-/* This sample executes a single-threaded kernel on the default device
+/* This is a basic example to illustrate the main components of a SYCL
+ * program. It executes a single-threaded kernel on the default device
  * (as determined by the SYCL implementation) whose only function is to
- * output the canonical hello world string. */
+ * output the canonical "hello world" string. */
 int main() {
-  default_selector selector;
-  queue myQueue(selector);
+  /* Selectors determine which device kernels will be dispatched to.
+   * Try using a host_selector, too! */
+  cl::sycl::default_selector selector;
 
-  myQueue.submit([&](handler& cgh) {
+  /* Queues are used to enqueue work.
+   * In this case we construct the queue using the selector. Users can create
+   * their own selectors to choose whatever kind of device they might need. */
+  cl::sycl::queue myQueue(selector);
+  std::cout << "Running on "
+            << myQueue.get_device().get_info<cl::sycl::info::device::name>()
+            << "\n";
+
+  /* C++ 11 lambda functions can be used to submit work to the queue.
+   * They set up data transfers, kernel compilation and the actual
+   * kernel execution. This submission has no data, only a "stream" object.
+   * Useful in debugging, it is a lot like an std::ostream. The handler
+   * object is used to control the scope certain operations can be done. */
+  myQueue.submit([&](cl::sycl::handler& cgh) {
     /* The stream object allows output to be generated from the kernel. It
-     * takes three parameters in its constructor: the total size of the
-     * memory to be allocated to it, the maximum size of any one statement
-     * in the stream and the command group handler (to bind it to a
-     * particular kernel execution, among other things). */
-    stream os(1024, 80, cgh);
+     * takes three parameters in its constructor. The first is the maximum
+     * output size in bytes, the second is how large [in bytes] the total
+     * output of any single << chain can be, and the third is the cgh,
+     * ensuring it can only be constructed inside a submit() call. */
+    cl::sycl::stream os(1024, 80, cgh);
 
+    /* single_task is the simplest way of executing a kernel on a
+     * SYCL device. A single thread executes the code inside the kernel
+     * lambda. The template parameter needs to be a unique name that
+     * the runtime can use to identify the kernel (since lambdas have
+     * no accessible name). */
     cgh.single_task<class hello_world>([=]() {
-      /* We use the stream operator on the stream object we created above to
-       * print to stdout from the device. */
-      os << "Hello, World!" << endl;
-
+      /* We use the stream operator on the stream object we created above
+       * to print to stdout from the device. */
+      os << "Hello, World!\n";
     });
   });
 


### PR DESCRIPTION
Improve comments on hello_world sample and ignore the html/ folder where html documentation output is stored.