### PR TITLE
Update the SDK with new ComputeCpp version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # YCM files
 *.ycm_extra_conf.py
 *.ycm_extra_conf.pyc
+.color_coded
 
 # build folder
 build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ script:
     - mkdir build
     - cd build 
     # Use the latest CE edition
-    - cmake ../ -DCOMPUTECPP_PACKAGE_ROOT_DIR=/tmp/ComputeCpp-CE-0.2.1-Linux/ -DCMAKE_MODULE_PATH=../../cmake/Modules -DCOMPUTECPP_DISABLE_GCC_DUAL_ABI=1
+    - cmake ../ -DCOMPUTECPP_PACKAGE_ROOT_DIR=/tmp/ComputeCpp-CE-0.3.0-Linux/ -DCMAKE_MODULE_PATH=../../cmake/Modules -DCOMPUTECPP_DISABLE_GCC_DUAL_ABI=1
     - make 
     - COMPUTECPP_TARGET="host" ctest -E opencl
 

--- a/.travis/computecpp_workaround.sh
+++ b/.travis/computecpp_workaround.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-cat .travis/additional_undef /tmp/ComputeCpp-CE-0.2.1-Linux/include/SYCL/sycl_builtins.h > /tmp/tmp_builtins
-mv /tmp/tmp_builtins /tmp/ComputeCpp-CE-0.2.1-Linux/include/SYCL/sycl_builtins.h
+cat .travis/additional_undef /tmp/ComputeCpp-CE-0.3.0-Linux/include/SYCL/sycl_builtins.h > /tmp/tmp_builtins
+mv /tmp/tmp_builtins /tmp/ComputeCpp-CE-0.3.0-Linux/include/SYCL/sycl_builtins.h
 
-cat .travis/additional_undef /tmp/ComputeCpp-CE-0.2.1-Linux/include/SYCL/host_relational_builtins.h > /tmp/tmp_builtins
-mv /tmp/tmp_builtins /tmp/ComputeCpp-CE-0.2.1-Linux/include/SYCL/host_relational_builtins.h
+cat .travis/additional_undef /tmp/ComputeCpp-CE-0.3.0-Linux/include/SYCL/host_relational_builtins.h > /tmp/tmp_builtins
+mv /tmp/tmp_builtins /tmp/ComputeCpp-CE-0.3.0-Linux/include/SYCL/host_relational_builtins.h

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -76,7 +76,7 @@ Requirements
 ------------
 
 * The samples should work with any SYCL 1.2 implementation, though have
-  only been tested with ComputeCpp CE Public Beta v0.2.1
+  only been tested with the ComputeCpp CE Public Beta
 
 * OpenCL 1.2-capable hardware and drivers with SPIR 1.2 support
 

--- a/documents/ComputeCpp_Anatomy_Of_App.asciidoc
+++ b/documents/ComputeCpp_Anatomy_Of_App.asciidoc
@@ -1,8 +1,7 @@
-== Community Edition (Beta) v. 0.2.1
+== Community Edition (Beta)
 :toc:
 :homepage: http://www.codeplay.com/computecpp
 :doctype: article
-:version: 0.2.1
 :author: Codeplay Software Ltd. <sycl@codeplay.com>
 :source-highlighter: coderay
 :coderay-css: style

--- a/documents/ComputeCpp_GettingStarted.asciidoc
+++ b/documents/ComputeCpp_GettingStarted.asciidoc
@@ -1,7 +1,6 @@
 :toc:
 :homepage: http://www.codeplay.com/computecpp
 :doctype: article
-:version: 0.2.1
 :author: Codeplay Software Ltd. <sycl@codeplay.com>
 :source-highlighter: coderay
 :coderay-css: style
@@ -82,15 +81,11 @@ image::{imageComputeCppLogo}[ComputeCpp (TM)]
 ==  ComputeCpp(TM) Community Edition (CE): Beta Release
  
 ComputeCpp Community Edition (CE) is a heterogeneous parallel programming
-platform that provides a beta pre-conformant implementantion of SYCL(TM) 1.2
-Khronos link:{syclSpecUrl}[specification].
+platform that provides a beta pre-conformant implementantion of the SYCL(TM)
+1.2 Khronos link:{syclSpecUrl}[specification].
  
-ComputeCpp CE {version} beta release includes the ComputeCpp CE Package version
-{version} and ComputeCpp CE SDK version {version}. The supported OpenCL 1.2
-platforms for ComputeCpp CE beta release, are AMD(TM) and Intel(TM).
- 
-This ComputeCpp Package version {version} supports SYCL pass:[C++] libraries 
-for better integration with pass:[C++] frameworks and applications like 
+ComputeCpp supports SYCL pass:[C++] libraries for better integration with
+pass:[C++] frameworks and applications like the
 link:{syclParallelStlUrl}[SYCL Parallel STL], math libraries like 
 link:{eigenSYCLUrl}[SYCL Eigen Tensor Library] and machine vision libraries. 
  
@@ -136,7 +131,7 @@ The output of this command will look something like this.
 ```
 ********************************************************************************
 
-ComputeCpp Info (CE 0.2.1)
+ComputeCpp Info (CE 0.3.0)
 
 ********************************************************************************
 

--- a/documents/ComputeCpp_Glossary.asciidoc
+++ b/documents/ComputeCpp_Glossary.asciidoc
@@ -3,7 +3,6 @@
 == Glossary
 :author: Codeplay Software Ltd.
 :doctype: article
-:version: 0.2.1
 
 ifdef::env-github[]
 :computecppUrl: https://computecpp.codeplay.com

--- a/documents/ComputeCpp_Integration_Guide.asciidoc
+++ b/documents/ComputeCpp_Integration_Guide.asciidoc
@@ -3,7 +3,6 @@ ComputeCpp : ComputeCpp Integration Guide
 
 :Cplusplus: C++
 :computePP: compute++
-:version: 0.2.1
 
 ifdef::env-github[]
 // Includes do not work on GitHub
@@ -63,7 +62,7 @@ The following sections delve into further details on the above topics.
 
 == What is ComputeCpp?
 
-The ComputeCpp(TM) Community Edition {version} targets the SYCL(TM) 1.2 Khronos
+The ComputeCpp(TM) Community Edition targets the SYCL(TM) 1.2 Khronos
 link:{syclSpecUrl}[specification]. This release provides a pre-conformance beta
 edition for OpenCL(TM) 1.2 devices with {glossarySpir} 1.2 support.
 ComputeCpp supports AMD(TM) and Intel(TM) OpenCL 1.2 devices with compatible

--- a/documents/ComputeCpp_Overview.asciidoc
+++ b/documents/ComputeCpp_Overview.asciidoc
@@ -1,6 +1,5 @@
 :homepage: http://www.codeplay.com/computecpp
 :doctype: article
-:version: 0.2.1
 :author: Codeplay Software Ltd. <sycl@codeplay.com>
 :source-highlighter: coderay
 :coderay-css: style
@@ -24,16 +23,13 @@ endif::env-github[]
 ==  ComputeCpp(TM) Community Edition (CE): Beta Release
 
 ComputeCpp Community Edition (CE) is a heterogeneous parallel programming
-platform that provides a beta pre-conformant implementantion of SYCL(TM) 1.2
-Khronos link:{syclSpecUrl}[specification].
+platform that provides a beta pre-conformant implementantion of the SYCL(TM)
+1.2 Khronos link:{syclSpecUrl}[specification].
 
-ComputeCpp CE {version} beta release includes the ComputeCpp CE Package version
-{version} and ComputeCpp CE SDK version {version}. The supported OpenCL 1.2
-platforms for ComputeCpp CE beta release, are AMD(TM) and Intel(TM).
-
-This ComputeCpp Package version {version} supports SYCL pass:[C++] libraries
-for better integration with pass:[C++] frameworks and applications like
-link:{syclParallelStlUrl}[SYCL Parallel STL], math libraries like link:{eigenSYCLUrl}[SYCL Eigen Tensor Library] and machine vision libraries.
+ComputeCpp supports SYCL pass:[C++] libraries for better integration with
+pass:[C++] frameworks and applications like the
+link:{syclParallelStlUrl}[SYCL Parallel STL], math libraries like
+link:{eigenSYCLUrl}[SYCL Eigen Tensor Library] and machine vision libraries.
 
 [ComputeCppPackage]
 .ComputeCpp Package Components


### PR DESCRIPTION
The vesion number has largely been removed from the repository, apart
from select places where a minimum version requirement has been
specified (like in the virtual pointer). The travis config needs a
more long-term, robust solution.