### PR TITLE
Use `buffer_allocator` instead of the `detail` allocators

### DIFF
--- a/utils/vptr/include/virtual_ptr.hpp
+++ b/utils/vptr/include/virtual_ptr.hpp
@@ -215,7 +215,8 @@ class PointerMapper {
   /* get_buffer.
    * Returns a buffer from the map using the pointer address
    */
-  template <typename buffer_allocator = cl::sycl::detail::base_allocator>
+  template <
+      typename buffer_allocator = cl::sycl::buffer_allocator<buffer_data_type>>
   cl::sycl::buffer<buffer_data_type, 1, buffer_allocator> get_buffer(
       const virtual_pointer_t ptr) {
     using buffer_t = cl::sycl::buffer<buffer_data_type, 1, buffer_allocator>;

--- a/utils/vptr/tests/accessor.cc
+++ b/utils/vptr/tests/accessor.cc
@@ -123,7 +123,7 @@ TEST(accessor, two_buffers) {
 
 TEST(accessor, allocator) {
   // an allocator type
-  using alloc_t = cl::sycl::detail::aligned_mem::aligned_allocator<uint8_t>;
+  using alloc_t = cl::sycl::buffer_allocator<uint8_t>;
 
   PointerMapper pMap;
   {


### PR DESCRIPTION
The `detail` namespace should be avoided if possible.