### PR TITLE
Add include-after CMake property

### DIFF
--- a/samples/using_functors/CMakeLists.txt
+++ b/samples/using_functors/CMakeLists.txt
@@ -3,6 +3,12 @@ add_executable(
   ${SOURCE_NAME}
   ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp
 )
+# This property is not necessary here, but demonstrates how to use it.
+# Forces the integration header to appear after the main code.
+set_property(
+  TARGET ${SOURCE_NAME}
+  PROPERTY COMPUTECPP_INCLUDE_AFTER 1
+)
 add_sycl_to_target(
   ${SOURCE_NAME}
   ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
This CMake change allows the user to specify that their integration
headers should appear before after the main code of the source file.
This allows users to put enums in the template arguments of their
kernels, even though this is not stricly legal in SYCL code (but lots
of existing code does it).

This is not on by default, because it requires that all kernels used
*must* have a forward definition visible to the host compiler inside
the integration header. For example, you can't have a class local to
a function, or more specifically something like:
  `cgh.parallel_for<class kernel_name>(range, [=]() { ... });`

This is an advanced property and is unlikely to be required by most
developers, but is there for the special cases.