### PR TITLE
CMakeLists.txt - minimum version before project command and append to CMAKE_MODULE_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.2.2)
 
 project(ComputeCpp-SDK)
 
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
 include(FindComputeCpp)
 
 # Set the host compiler C++ standard to C++ 14

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(ComputeCpp-SDK)
-
 cmake_minimum_required(VERSION 3.2.2)
+
+project(ComputeCpp-SDK)
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
 include(FindComputeCpp)


### PR DESCRIPTION
Hi,

I updated the CMakeLists.txt to change the order of the project command As specified at the documentation: https://cmake.org/cmake/help/latest/command/project.html

And I also updated the overwrite of CMAKE_MODULE_PATH, which is better to append, so you don't lose the current values.

Thanks