### PR TITLE
Allow to add existing buffer

### DIFF
--- a/include/vptr/virtual_ptr.hpp
+++ b/include/vptr/virtual_ptr.hpp
@@ -318,7 +318,7 @@ class PointerMapper {
   /* add_pointer.
    * Adds an existing pointer to the map and returns the virtual pointer id.
    */
-  inline virtual_pointer_t add_pointer(buffer_t &b) {
+  inline virtual_pointer_t add_pointer(const buffer_t &b) {
     return add_pointer_impl(b);
   }
 
@@ -408,7 +408,7 @@ class PointerMapper {
 
   /* add_pointer_impl.
    * Adds a pointer to the map and returns the virtual pointer id.
-   * BufferT is either a buffer_t& or a buffer_t&&.
+   * BufferT is either a const buffer_t& or a buffer_t&&.
    */
   template <class BufferT>
   virtual_pointer_t add_pointer_impl(BufferT b) {


### PR DESCRIPTION
This is a change we have in Eigen which allow to use the library with existing SYCL buffers.
So one can write
```
buffer<float, 1> buf(range<1>(10));
float* p = static_cast<float *>(static_cast<void *>(pMap.add_pointer(buf)));
```
and use p as if it were malloc'ed.

I'd like to make sure that this won't cause any issue.