### PR TITLE
Add method release_pointer to vptr

### DIFF
--- a/include/vptr/virtual_ptr.hpp
+++ b/include/vptr/virtual_ptr.hpp
@@ -485,7 +485,7 @@ class PointerMapper {
  * The pointer is allowed to be reused only if ReUse if true.
  */
 template <>
-void PointerMapper::remove_pointer<false>(const virtual_pointer_t ptr) {
+inline void PointerMapper::remove_pointer<false>(const virtual_pointer_t ptr) {
   m_pointerMap.erase(this->get_node(ptr));
 }
 

--- a/tests/vptr/basic.cc
+++ b/tests/vptr/basic.cc
@@ -167,6 +167,13 @@ TEST(pointer_mapper, reuse_ptr) {
     ASSERT_FALSE(PointerMapper::is_nullptr(shouldBeTheSame));
     ASSERT_EQ(pMap.count(), 3u);
     ASSERT_EQ(shouldBeTheSame, reused);
+
+    SYCLfree(shouldBeTheSame, pMap);
+    ASSERT_EQ(pMap.count(), 2u);
+    SYCLfree(end, pMap);
+    ASSERT_EQ(pMap.count(), 1u);
+    SYCLfree(initial, pMap);
+    ASSERT_EQ(pMap.count(), 0u);
   }
 }
 
@@ -193,7 +200,7 @@ TEST(pointer_mapper, do_not_reuse_ptr) {
     ASSERT_FALSE(PointerMapper::is_nullptr(end));
     ASSERT_EQ(pMap.count(), 3u);
 
-    // We free the intermediate one and forbit it to be reuse
+    // We free the intermediate one and forbid it to be reused
     SYCLfree<false>(not_reused, pMap);
     ASSERT_EQ(pMap.count(), 2u);
 
@@ -202,6 +209,13 @@ TEST(pointer_mapper, do_not_reuse_ptr) {
     ASSERT_FALSE(PointerMapper::is_nullptr(shouldBeNew));
     ASSERT_EQ(pMap.count(), 3u);
     ASSERT_NE(shouldBeNew, not_reused);
+
+    SYCLfree(shouldBeNew, pMap);
+    ASSERT_EQ(pMap.count(), 2u);
+    SYCLfree(end, pMap);
+    ASSERT_EQ(pMap.count(), 1u);
+    SYCLfree(initial, pMap);
+    ASSERT_EQ(pMap.count(), 0u);
   }
 }
 
@@ -239,6 +253,13 @@ TEST(pointer_mapper, add_existing_buffer) {
     ASSERT_FALSE(PointerMapper::is_nullptr(shouldBeTheSame));
     ASSERT_EQ(pMap.count(), 3u);
     ASSERT_EQ(shouldBeTheSame, reused);
+
+    SYCLfree(shouldBeTheSame, pMap);
+    ASSERT_EQ(pMap.count(), 2u);
+    SYCLfree(end, pMap);
+    ASSERT_EQ(pMap.count(), 1u);
+    SYCLfree(initial, pMap);
+    ASSERT_EQ(pMap.count(), 0u);
   }
 }
 

--- a/tests/vptr/basic.cc
+++ b/tests/vptr/basic.cc
@@ -170,6 +170,78 @@ TEST(pointer_mapper, reuse_ptr) {
   }
 }
 
+TEST(pointer_mapper, do_not_reuse_ptr) {
+  PointerMapper pMap;
+  {
+    ASSERT_EQ(pMap.count(), 0u);
+
+    // First we insert a large buffer
+    void *initial = SYCLmalloc(100 * sizeof(int), pMap);
+    ASSERT_NE(initial, nullptr);
+    ASSERT_FALSE(PointerMapper::is_nullptr(initial));
+    ASSERT_EQ(pMap.count(), 1u);
+
+    // Now we insert a small one, that could have been reused
+    void *not_reused = SYCLmalloc(10 * sizeof(int), pMap);
+    ASSERT_NE(not_reused, nullptr);
+    ASSERT_FALSE(PointerMapper::is_nullptr(not_reused));
+    ASSERT_EQ(pMap.count(), 2u);
+
+    // Another large buffer
+    void *end = SYCLmalloc(100 * sizeof(int), pMap);
+    ASSERT_NE(end, nullptr);
+    ASSERT_FALSE(PointerMapper::is_nullptr(end));
+    ASSERT_EQ(pMap.count(), 3u);
+
+    // We free the intermediate one and forbit it to be reuse
+    SYCLfree<false>(not_reused, pMap);
+    ASSERT_EQ(pMap.count(), 2u);
+
+    void *shouldBeNew = SYCLmalloc(10 * sizeof(int), pMap);
+    ASSERT_NE(shouldBeNew, nullptr);
+    ASSERT_FALSE(PointerMapper::is_nullptr(shouldBeNew));
+    ASSERT_EQ(pMap.count(), 3u);
+    ASSERT_NE(shouldBeNew, not_reused);
+  }
+}
+
+TEST(pointer_mapper, add_existing_buffer) {
+  PointerMapper pMap;
+  {
+    ASSERT_EQ(pMap.count(), 0u);
+
+    // First we insert a large buffer
+    cl::sycl::buffer<buffer_data_type_t, 1> buf1((cl::sycl::range<1>(100 * sizeof(int))));
+    void *initial = static_cast<void*>(pMap.add_pointer(buf1));
+    ASSERT_NE(initial, nullptr);
+    ASSERT_FALSE(PointerMapper::is_nullptr(initial));
+    ASSERT_EQ(pMap.count(), 1u);
+
+    // Now we insert a small one, that will be reused
+    cl::sycl::buffer<buffer_data_type_t, 1> buf2((cl::sycl::range<1>(10 * sizeof(int))));
+    void *reused = static_cast<void*>(pMap.add_pointer(buf2));
+    ASSERT_NE(reused, nullptr);
+    ASSERT_FALSE(PointerMapper::is_nullptr(reused));
+    ASSERT_EQ(pMap.count(), 2u);
+
+    // Another large buffer, the original malloc can still be used
+    void *end = SYCLmalloc(100 * sizeof(int), pMap);
+    ASSERT_NE(end, nullptr);
+    ASSERT_FALSE(PointerMapper::is_nullptr(end));
+    ASSERT_EQ(pMap.count(), 3u);
+
+    // We free the intermediate one
+    SYCLfree(reused, pMap);
+    ASSERT_EQ(pMap.count(), 2u);
+
+    void *shouldBeTheSame = SYCLmalloc(10 * sizeof(int), pMap);
+    ASSERT_NE(shouldBeTheSame, nullptr);
+    ASSERT_FALSE(PointerMapper::is_nullptr(shouldBeTheSame));
+    ASSERT_EQ(pMap.count(), 3u);
+    ASSERT_EQ(shouldBeTheSame, reused);
+  }
+}
+
 TEST(pointer_mapper, multiple_alloc_free) {
   PointerMapper pMap;
   size_t numAllocations = (1 << 9);


### PR DESCRIPTION
The idea is to allow the user to remove pointers without reusing them.
It is particularly useful for sub-buffers because we don't want to keep their virtual pointer. With that it is possible to use Eigen with sub-buffers.

I am not too sure about the method name. Maybe it would make more sense to swap it with the existing remove_pointer (i.e. release_pointer allow to re-use the pointer but remove_pointer does not)?. I'll make sure Eigen synchronises with the latest changes we make here.