### PR TITLE
Update the SDK to ComputeCpp v0.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,6 @@ script:
     ###########################
     - mkdir build
     - cd build
-    - cmake ../ -DCOMPUTECPP_PACKAGE_ROOT_DIR=/tmp/ComputeCpp-CE-0.4.0-Ubuntu-14.04-64bit -DCOMPUTECPP_DISABLE_GCC_DUAL_ABI=1 -DCOMPUTECPP_SDK_BUILD_TESTS=1
+    - cmake ../ -DCOMPUTECPP_PACKAGE_ROOT_DIR=/tmp/ComputeCpp-CE-0.5.0-Ubuntu-14.04-64bit -DCOMPUTECPP_DISABLE_GCC_DUAL_ABI=1 -DCOMPUTECPP_SDK_BUILD_TESTS=1
     - make -j2
     - COMPUTECPP_TARGET="host" ctest -V -E opencl

--- a/.travis/build_computecpp.sh
+++ b/.travis/build_computecpp.sh
@@ -5,7 +5,7 @@ set -ev
 ###########################
 # Get ComputeCpp
 ###########################
-wget --no-check-certificate https://computecpp.codeplay.com/downloads/computecpp-ce/0.4.0/ubuntu-14.04-64bit.tar.gz
+wget --no-check-certificate https://computecpp.codeplay.com/downloads/computecpp-ce/0.5.0/ubuntu-14.04-64bit.tar.gz
 tar -xzf ubuntu-14.04-64bit.tar.gz -C /tmp
 # Workaround for C99 definition conflict
 bash .travis/computecpp_workaround.sh

--- a/.travis/computecpp_workaround.sh
+++ b/.travis/computecpp_workaround.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-cat .travis/additional_undef /tmp/ComputeCpp-CE-0.4.0-Ubuntu-14.04-64bit/include/SYCL/sycl_builtins.h > /tmp/tmp_builtins
-mv /tmp/tmp_builtins /tmp/ComputeCpp-CE-0.4.0-Ubuntu-14.04-64bit/include/SYCL/sycl_builtins.h
+cat .travis/additional_undef /tmp/ComputeCpp-CE-0.5.0-Ubuntu-14.04-64bit/include/SYCL/sycl_builtins.h > /tmp/tmp_builtins
+mv /tmp/tmp_builtins /tmp/ComputeCpp-CE-0.5.0-Ubuntu-14.04-64bit/include/SYCL/sycl_builtins.h
 
-cat .travis/additional_undef /tmp/ComputeCpp-CE-0.4.0-Ubuntu-14.04-64bit/include/SYCL/host_relational_builtins.h > /tmp/tmp_builtins
-mv /tmp/tmp_builtins /tmp/ComputeCpp-CE-0.4.0-Ubuntu-14.04-64bit/include/SYCL/host_relational_builtins.h
+cat .travis/additional_undef /tmp/ComputeCpp-CE-0.5.0-Ubuntu-14.04-64bit/include/SYCL/host_relational_builtins.h > /tmp/tmp_builtins
+mv /tmp/tmp_builtins /tmp/ComputeCpp-CE-0.5.0-Ubuntu-14.04-64bit/include/SYCL/host_relational_builtins.h

--- a/samples/async-handler/async-handler.cpp
+++ b/samples/async-handler/async-handler.cpp
@@ -97,7 +97,8 @@ int main() {
 
   /* Construct a queue with an async_handler. */
   {
-    queue myQueue(mySelector, asyncHandler);
+    device myDevice(mySelector);
+    queue myQueue(myDevice, asyncHandler);
     myQueue.submit(cgh_error);
 
     /* The asynchronous handler is called at this point.
@@ -118,7 +119,8 @@ int main() {
 
   /* Construct a context without an async_handler. */
   {
-    context myContext(mySelector, false);
+    device myDevice(mySelector);
+    context myContext(myDevice);
     queue myQueue(myContext, mySelector);
     myQueue.submit(cgh_error);
 

--- a/samples/images/images.cpp
+++ b/samples/images/images.cpp
@@ -45,10 +45,10 @@ int main() {
      * images are created from a host pointer like buffers, however, instead of
      * specifying a type you provide the channel order and channel type when
      * constructing them. */
-    image<2> srcImage(src, image_format::channel_order::RGBA,
-                      image_format::channel_type::FLOAT, range<2>(16, 16));
-    image<2> destImage(dest, image_format::channel_order::RGBA,
-                       image_format::channel_type::FLOAT, range<2>(16, 16));
+    image<2> srcImage(src, image_channel_order::rgba, image_channel_type::fp32,
+                      range<2>(16, 16));
+    image<2> destImage(dest, image_channel_order::rgba,
+                       image_channel_type::fp32, range<2>(16, 16));
 
     /* We can retrieve the size of the image by calling get_size(). */
     std::cout << "Image size: " << srcImage.get_size() << std::endl;
@@ -77,8 +77,7 @@ int main() {
        * SYCL's images and samplers map very well to the underlying OpenCL
        * constructs. OpenCL documentation has a more full discussion of
        * how images and samplers work. */
-      sampler smpl(false, sampler_addressing_mode::clamp,
-                   sampler_filter_mode::nearest);
+      sampler smpl(false, addressing_mode::clamp, filtering_mode::nearest);
 
       cgh.parallel_for<class mod_image>(range<2>(16, 16), [=](item<2> item) {
 
@@ -89,13 +88,13 @@ int main() {
         /* In SYCL images are read using a subscript operator to provide the
          * coordinates, with an optional function call operator preceding it
          * to provide a sampler. */
-        float4 pixel = inPtr(smpl)[coords];
+        float4 pixel = inPtr.read(coords, smpl);
 
         pixel *= 10.0f;
 
         /* Images are written to in a similar fashion, only without a
          * sampler. */
-        outPtr[coords] = pixel;
+        outPtr.write(coords, pixel);
       });
     });
 

--- a/samples/matrix-multiply/matrix-multiply.cpp
+++ b/samples/matrix-multiply/matrix-multiply.cpp
@@ -139,17 +139,17 @@ bool local_mxm(cl::sycl::queue& q, T* MA, T* MB, T* MC, int matSize) {
   blockSize = std::min(matSize, blockSize);
 
   {
+    /* Buffers can be constructed with property lists. In this example,
+     * the buffer is given the property "use host pointer", which tells
+     * the runtime to use the host pointer for all data storage (instead
+     * of making copies internally). Additionally, when running on a
+     * device that shares memory with the host (for example a CPU),
+     * "zero-copy" memory optimisations can be used by the driver. */
     range<1> dimensions(matSize * matSize);
-    /* Buffers optionally take allocators as a template argument. In this
-     * example, the buffer is given the map_allocator, which forces the
-     * runtime to use the host pointer for all data storage (instead of
-     * making copies internally). Additionally, when running on an OpenCL
-     * device that shares memory with the host (for example a CPU
-     * implementation), "zero-copy" memory optimisations could be used by
-     * the implementation. */
-    buffer<T, 1, map_allocator<T>> bA(MA, dimensions);
-    buffer<T, 1, map_allocator<T>> bB(MB, dimensions);
-    buffer<T, 1, map_allocator<T>> bC(MC, dimensions);
+    const property_list props = {property::buffer::use_host_ptr()};
+    buffer<T> bA(MA, dimensions, props);
+    buffer<T> bB(MB, dimensions, props);
+    buffer<T> bC(MC, dimensions, props);
 
     q.submit([&](handler& cgh) {
       auto pA = bA.template get_access<access::mode::read>(cgh);

--- a/samples/simple-private-memory/simple-private-memory.cpp
+++ b/samples/simple-private-memory/simple-private-memory.cpp
@@ -35,7 +35,7 @@ static inline cl::sycl::id<1> get_global_id(cl::sycl::group<1>& group,
                                             cl::sycl::item<1>& item) {
   auto groupID = group.get();
   auto localR = item.get_range();
-  auto localID = item.get();
+  auto localID = item.get_id();
   return cl::sycl::id<1>(groupID.get(0) * localR.get(0) + localID.get(0));
 }
 

--- a/samples/smart-pointer/smart-pointer.cpp
+++ b/samples/smart-pointer/smart-pointer.cpp
@@ -121,13 +121,15 @@ int main() {
   }
 
   {
-    /* The special map_allocator maps a host pointer to the device.
-     * All runtime allocations of memory will return the same p pointer.
-     * When using map_allocator, all host accessors update the
-     * user-given host memory. This can benefit performance, though you
-     * should always profile to see if it actually makes a difference. */
     {
-      buffer<int, 1, map_allocator<int>> buf(p, range<1>(nElems));
+      /* The property "use_host_ptr" tells the runtime that the user
+       * pointer passed to the constructor should be used to store all
+       * data, rather than new internal allocations. When using this,
+       * all host accessors update the user-given host memory. This can
+       * improve performance, though you should always profile to see
+       * if it actually makes a difference. */
+      buffer<int, 1> buf(p, range<1>(nElems),
+                         {property::buffer::use_host_ptr()});
 
       myQueue.submit([&](handler& cgh) {
         auto myRange = nd_range<2>(range<2>(6, 2), range<2>(2, 1));

--- a/samples/template-function-object/template-function-object.cpp
+++ b/samples/template-function-object/template-function-object.cpp
@@ -52,8 +52,7 @@ class vector_add_kernel {
       accessor<dataT, 1, access::mode::read, access::target::global_buffer>;
   using write_accessor =
       accessor<dataT, 1, access::mode::write, access::target::global_buffer>;
-  vector_add_kernel(read_accessor ptrA, read_accessor ptrB,
-                     write_accessor ptrC)
+  vector_add_kernel(read_accessor ptrA, read_accessor ptrB, write_accessor ptrC)
       : m_ptrA(ptrA), m_ptrB(ptrB), m_ptrC(ptrC) {}
 
   /* We define this object's function call operator to match the parallel_for
@@ -61,7 +60,7 @@ class vector_add_kernel {
    * item rather than an nd_item. */
   void operator()(item<1> item) {
     /* This is a standard vector add, as seen in other samples. */
-    m_ptrC[item.get()] = m_ptrA[item.get()] + m_ptrB[item.get()];
+    m_ptrC[item.get_id()] = m_ptrA[item.get_id()] + m_ptrB[item.get_id()];
   }
 
  private:

--- a/samples/using-function-objects/using-function-objects.cpp
+++ b/samples/using-function-objects/using-function-objects.cpp
@@ -59,7 +59,7 @@ class my_function_object {
    * requirements of the parallel_for API, i.e. with a single item parameter,
    * that defines the kernel. In this case the kernel simply assigns the random
    * number to the accessor. */
-  void operator()(item<1> item) { m_ptr[item.get()] = m_randumNum; }
+  void operator()(item<1> item) { m_ptr[item.get_id()] = m_randumNum; }
 
   /* A member function to retrieve the random number. Function objects are still
    * standard C++ classes and can be used as normal on the host. */


### PR DESCRIPTION
Some 1.2.1 features are missing and therefore are yet to change
(updates to the image normalisation flags for samplers for example).