### PR TITLE
Update SDK to ComputeCpp v0.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,6 @@ script:
     ###########################
     - mkdir build
     - cd build
-    - cmake ../ -DCOMPUTECPP_PACKAGE_ROOT_DIR=/tmp/ComputeCpp-CE-0.5.0-Ubuntu-14.04-64bit -DCOMPUTECPP_DISABLE_GCC_DUAL_ABI=1 -DCOMPUTECPP_SDK_BUILD_TESTS=1
+    - cmake ../ -DCOMPUTECPP_PACKAGE_ROOT_DIR=/tmp/computecpp -DCOMPUTECPP_SDK_BUILD_TESTS=1
     - make -j2
     - COMPUTECPP_TARGET="host" ctest -V -E opencl

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,6 @@ script:
     ###########################
     - mkdir build
     - cd build
-    - cmake ../ -DCOMPUTECPP_PACKAGE_ROOT_DIR=/tmp/computecpp -DCOMPUTECPP_SDK_BUILD_TESTS=1
+    - cmake ../ -DCOMPUTECPP_PACKAGE_ROOT_DIR=/tmp/computecpp -DCOMPUTECPP_SDK_BUILD_TESTS=1 -DCOMPUTECPP_DISABLE_GCC_DUAL_ABI=1
     - make -j2
     - COMPUTECPP_TARGET="host" ctest -V -E opencl

--- a/.travis/build_computecpp.sh
+++ b/.travis/build_computecpp.sh
@@ -5,7 +5,7 @@ set -ev
 ###########################
 # Get ComputeCpp
 ###########################
-wget --no-check-certificate https://computecpp.codeplay.com/downloads/computecpp-ce/0.5.1/ubuntu-16.04-64bit.tar.gz
+wget --no-check-certificate https://computecpp.codeplay.com/downloads/computecpp-ce/0.5.1/ubuntu-14.04-64bit.tar.gz
 tar -xzf ubuntu-14.04-64bit.tar.gz -C /tmp
 mv /tmp/ComputeCpp-CE-0.5.1-Ubuntu-14.04-64bit /tmp/computecpp
 # Workaround for C99 definition conflict

--- a/.travis/build_computecpp.sh
+++ b/.travis/build_computecpp.sh
@@ -5,7 +5,8 @@ set -ev
 ###########################
 # Get ComputeCpp
 ###########################
-wget --no-check-certificate https://computecpp.codeplay.com/downloads/computecpp-ce/0.5.0/ubuntu-14.04-64bit.tar.gz
-tar -xzf ubuntu-14.04-64bit.tar.gz -C /tmp
+wget --no-check-certificate https://computecpp.codeplay.com/downloads/computecpp-ce/0.5.1/ubuntu-16.04-64bit.tar.gz
+tar -xzf ubuntu-16.04-64bit.tar.gz -C /tmp
+mv /tmp/ComputeCpp-CE-0.5.0-Ubuntu-16.04-64bit /tmp/computecpp
 # Workaround for C99 definition conflict
 bash .travis/computecpp_workaround.sh

--- a/.travis/build_computecpp.sh
+++ b/.travis/build_computecpp.sh
@@ -7,6 +7,6 @@ set -ev
 ###########################
 wget --no-check-certificate https://computecpp.codeplay.com/downloads/computecpp-ce/0.5.1/ubuntu-16.04-64bit.tar.gz
 tar -xzf ubuntu-16.04-64bit.tar.gz -C /tmp
-mv /tmp/ComputeCpp-CE-0.5.0-Ubuntu-16.04-64bit /tmp/computecpp
+mv /tmp/ComputeCpp-CE-0.5.1-Ubuntu-16.04-64bit /tmp/computecpp
 # Workaround for C99 definition conflict
 bash .travis/computecpp_workaround.sh

--- a/.travis/build_computecpp.sh
+++ b/.travis/build_computecpp.sh
@@ -6,7 +6,7 @@ set -ev
 # Get ComputeCpp
 ###########################
 wget --no-check-certificate https://computecpp.codeplay.com/downloads/computecpp-ce/0.5.1/ubuntu-16.04-64bit.tar.gz
-tar -xzf ubuntu-16.04-64bit.tar.gz -C /tmp
-mv /tmp/ComputeCpp-CE-0.5.1-Ubuntu-16.04-64bit /tmp/computecpp
+tar -xzf ubuntu-14.04-64bit.tar.gz -C /tmp
+mv /tmp/ComputeCpp-CE-0.5.1-Ubuntu-14.04-64bit /tmp/computecpp
 # Workaround for C99 definition conflict
 bash .travis/computecpp_workaround.sh

--- a/.travis/computecpp_workaround.sh
+++ b/.travis/computecpp_workaround.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-cat .travis/additional_undef /tmp/ComputeCpp-CE-0.5.0-Ubuntu-14.04-64bit/include/SYCL/sycl_builtins.h > /tmp/tmp_builtins
-mv /tmp/tmp_builtins /tmp/ComputeCpp-CE-0.5.0-Ubuntu-14.04-64bit/include/SYCL/sycl_builtins.h
+cat .travis/additional_undef /tmp/computecpp/include/SYCL/sycl_builtins.h > /tmp/tmp_builtins
+mv /tmp/tmp_builtins /tmp/computecpp/include/SYCL/sycl_builtins.h
 
-cat .travis/additional_undef /tmp/ComputeCpp-CE-0.5.0-Ubuntu-14.04-64bit/include/SYCL/host_relational_builtins.h > /tmp/tmp_builtins
-mv /tmp/tmp_builtins /tmp/ComputeCpp-CE-0.5.0-Ubuntu-14.04-64bit/include/SYCL/host_relational_builtins.h
+cat .travis/additional_undef /tmp/computecpp/include/SYCL/host_relational_builtins.h > /tmp/tmp_builtins
+mv /tmp/tmp_builtins /tmp/computecpp/include/SYCL/host_relational_builtins.h

--- a/samples/images/images.cpp
+++ b/samples/images/images.cpp
@@ -83,7 +83,7 @@ int main() {
 
         /* SYCL vectors are used to specify the location of the image to
          * access. */
-        auto coords = int2(item.get(0), item.get(1));
+        auto coords = int2(item[0], item[1]);
 
         /* In SYCL images are read using a subscript operator to provide the
          * coordinates, with an optional function call operator preceding it

--- a/samples/ivka/ivka.cpp
+++ b/samples/ivka/ivka.cpp
@@ -39,11 +39,11 @@ struct Bar : Foo {
 };
 
 using namespace cl::sycl;
-using m = cl::sycl::access::mode;
-using t = cl::sycl::access::target;
+using acc_mode = cl::sycl::access::mode;
+using acc_target = cl::sycl::access::target;
 
 static_assert(is_valid_kernel_arg<
-    accessor<int, 1, m::read, t::global_buffer>>::value, "");
+    accessor<int, 1, acc_mode::read, acc_target::global_buffer>>::value, "");
 static_assert(is_valid_kernel_arg<double>::value, "");
 static_assert(is_valid_kernel_arg<Foo>::value, "");
 static_assert(!is_valid_kernel_arg<Bar>::value, "");

--- a/samples/ivka/ivka.cpp
+++ b/samples/ivka/ivka.cpp
@@ -39,9 +39,11 @@ struct Bar : Foo {
 };
 
 using namespace cl::sycl;
+using m = cl::sycl::access::mode;
+using t = cl::sycl::access::target;
 
-static_assert(is_valid_kernel_arg<accessor<int, 1, access::mode::read,
-                                 access::target::global_buffer>>::value, "");
+static_assert(is_valid_kernel_arg<
+    accessor<int, 1, m::read, t::global_buffer>>::value, "");
 static_assert(is_valid_kernel_arg<double>::value, "");
 static_assert(is_valid_kernel_arg<Foo>::value, "");
 static_assert(!is_valid_kernel_arg<Bar>::value, "");


### PR DESCRIPTION
More 1.2.1 changes have been integrated, though we're not 100% there
yet. Old code will continue to work but will show deprecation messages
(which I don't think are useful to see when building the SDK).