### PR TITLE
Add step to remove any duplicate ComputeCpp flags

### DIFF
--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -251,6 +251,7 @@ function(__build_spir targetName sourceFile binaryDir fileCounter)
         ${device_compiler_includes})
     endforeach()
   endif()
+  list(REMOVE_DUPLICATES device_compiler_includes)
 
   # Obtain language standard of the file
   set(device_compiler_cxx_standard)


### PR DESCRIPTION
When adding include directories it is easy to have the same include
directory linked to multiple cmake targets. Filter out any duplicate
include directories (and any other duplicate flags) before passing to
the compiler to keep the commands as terse as possible.