### PR TITLE
Use `static constexpr` instead of `constexpr` (#95)

### DIFF
--- a/samples/gaussian-blur/gaussian-blur.cpp
+++ b/samples/gaussian-blur/gaussian-blur.cpp
@@ -106,7 +106,7 @@ int main(int argc, char* argv[]) {
   outputData = new char[inputWidth * inputHeight * numChannels];
 
   const float pi = std::atan(1) * 4;
-  constexpr auto stddev = 4;
+  static constexpr auto stddev = 4;
 
   /* This range represents the full amount of work to be done across the
    * image. We dispatch one thread per pixel. */


### PR DESCRIPTION
When MSVC captures a `constexpr` variable inside a lambda, it is no longer `constexpr` within the lambda. The solution is to make it `static constexpr`. This MR fixes the Gaussian blur test when using MSVC.