### PR TITLE
Vptr: handle alloc zero

### DIFF
--- a/include/vptr/README.adoc
+++ b/include/vptr/README.adoc
@@ -68,7 +68,8 @@ To retrieve the SYCL buffer from the virtual pointer, use the
 *codeplay::PointerMapper::get_buffer* function. The offset into the SYCL buffer
 on the device side can be retrieved using the
 *codeplay::PointerMapper::get_offset* function.
-A pointer of size zero can be malloc'ed and free'd but cannot be accessed.
+A pointer of size zero can be malloc'ed and free'd but will throw an exception
+if accessed.
 
 See the tests for basic usage examples.
 Note that the pointer cannot be dereferenced on the host, but host accessors

--- a/include/vptr/README.adoc
+++ b/include/vptr/README.adoc
@@ -68,6 +68,7 @@ To retrieve the SYCL buffer from the virtual pointer, use the
 *codeplay::PointerMapper::get_buffer* function. The offset into the SYCL buffer
 on the device side can be retrieved using the
 *codeplay::PointerMapper::get_offset* function.
+A pointer of size zero can be malloc'ed and free'd but cannot be accessed.
 
 See the tests for basic usage examples.
 Note that the pointer cannot be dereferenced on the host, but host accessors

--- a/include/vptr/virtual_ptr.hpp
+++ b/include/vptr/virtual_ptr.hpp
@@ -211,6 +211,9 @@ class PointerMapper {
     if (this->count() == 0) {
       throw std::out_of_range("There are no pointers allocated");
     }
+    if (is_nullptr(ptr)) {
+      throw std::out_of_range("Cannot access null pointer");
+    }
     // The previous element to the lower bound is the node that
     // holds this memory address
     auto node = m_pointerMap.lower_bound(ptr);
@@ -382,6 +385,9 @@ class PointerMapper {
    */
   template <bool ReUse = true>
   void remove_pointer(const virtual_pointer_t ptr) {
+    if (is_nullptr(ptr)) {
+      return;
+    }
     auto node = this->get_node(ptr);
 
     node->second.m_free = true;
@@ -485,6 +491,9 @@ class PointerMapper {
  */
 template <>
 inline void PointerMapper::remove_pointer<false>(const virtual_pointer_t ptr) {
+  if (is_nullptr(ptr)) {
+    return;
+  }
   m_pointerMap.erase(this->get_node(ptr));
 }
 
@@ -497,6 +506,9 @@ inline void PointerMapper::remove_pointer<false>(const virtual_pointer_t ptr) {
  */
 template <typename buffer_allocator = buffer_allocator_default_t>
 inline void* SYCLmalloc(size_t size, PointerMapper& pMap) {
+  if (size == 0) {
+    return nullptr;
+  }
   // Create a generic buffer of the given size
   using buffer_t = cl::sycl::buffer<buffer_data_type_t, 1, buffer_allocator>;
   auto thePointer = pMap.add_pointer(buffer_t(cl::sycl::range<1>{size}));


### PR DESCRIPTION
Fixes: https://github.com/codeplaysoftware/computecpp-sdk/issues/109
After discussing with @r-potter and Mehdi we think the best solution is to allow to malloc a 0 sized pointer and to free it without changing the map. Accessing this pointer throws an exception.