### PR TITLE
Fix const capture crash on Windows CMake builds

### DIFF
--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -62,16 +62,6 @@ mark_as_advanced(COMPUTECPP_DISABLE_GCC_DUAL_ABI)
 set(COMPUTECPP_USER_FLAGS "" CACHE STRING "User flags for compute++")
 mark_as_advanced(COMPUTECPP_USER_FLAGS)
 
-# Platform-specific arguments
-if(MSVC)
-  # If you encounter problems with types such as char16_t and char32_t not
-  # being defined, you can try to enable the flag below.
-  # See also:
-  # https://github.com/codeplaysoftware/computecpp-sdk/pull/51#discussion_r139399093
-  # https://github.com/codeplaysoftware/computecpp-sdk/issues/112
-  # set (COMPUTECPP_PLATFORM_SPECIFIC_ARGS "-fno-ms-compatibility")
-endif()
-
 # Find OpenCL package
 find_package(OpenCL REQUIRED)
 
@@ -284,7 +274,6 @@ function(__build_spir targetName sourceFile binaryDir fileCounter)
     COMMAND ${COMPUTECPP_DEVICE_COMPILER}
             ${COMPUTECPP_DEVICE_COMPILER_FLAGS}
             -isystem ${COMPUTECPP_INCLUDE_DIRECTORY}
-            ${COMPUTECPP_PLATFORM_SPECIFIC_ARGS}
             ${device_compiler_includes}
             -o ${outputSyclFile}
             -c ${sourceFile}

--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -64,9 +64,12 @@ mark_as_advanced(COMPUTECPP_USER_FLAGS)
 
 # Platform-specific arguments
 if(MSVC)
-  # Workaround to an unfixed Clang bug, rationale:
+  # If you encounter problems with types such as char16_t and char32_t not
+  # being defined, you can try to enable the flag below.
+  # See also:
   # https://github.com/codeplaysoftware/computecpp-sdk/pull/51#discussion_r139399093
-  set (COMPUTECPP_PLATFORM_SPECIFIC_ARGS "-fno-ms-compatibility")
+  # https://github.com/codeplaysoftware/computecpp-sdk/issues/112
+  # set (COMPUTECPP_PLATFORM_SPECIFIC_ARGS "-fno-ms-compatibility")
 endif()
 
 # Find OpenCL package


### PR DESCRIPTION
This fixes #112.

All but one sample are confirmed to still work on Windows after the change. The one that's not working is `vptr`, however, the same crash already occurred before the change. One additional caveat: Since I don't have a compatible GPU available on my Windows machine, I had to change the `gpu_selector` in `opencl-c-interop` to a `cpu_selector`.

This is also a necessary (but not sufficient) change in order to make the tests build on Windows again. I'll submit another PR for this in a minute.

Lastly, note that I had to roll back from ComputeCpp 0.8.0 to 0.7.0, since the former seems to have broken some of the samples (also on Linux).