### PR TITLE
Update SDK to ComputeCpp v0.8.0

### DIFF
--- a/.travis/build_computecpp.sh
+++ b/.travis/build_computecpp.sh
@@ -2,11 +2,9 @@
 
 set -ev
 
-###########################
 # Get ComputeCpp
-###########################
-wget --no-check-certificate https://computecpp.codeplay.com/downloads/computecpp-ce/0.7.0/ubuntu-14.04-64bit.tar.gz
-tar -xzf ubuntu-14.04-64bit.tar.gz -C /tmp
-mv /tmp/ComputeCpp-CE-0.7.0-Ubuntu-14.04-x86_64 /tmp/computecpp
+wget --no-check-certificate https://computecpp.codeplay.com/downloads/computecpp-ce/0.8.0/ubuntu-14.04-64bit.tar.gz
+mkdir -p /tmp/computecpp
+tar -xzf ubuntu-14.04-64bit.tar.gz -C /tmp/computecpp --strip-components=1
 # Workaround for C99 definition conflict
 bash .travis/computecpp_workaround.sh

--- a/samples/images/images.cpp
+++ b/samples/images/images.cpp
@@ -104,9 +104,8 @@ int main() {
     return 2;
   }
 
-  /* We check the result is correct. */
-  if (dest[0].x() == 10.0f && dest[0].y() == 20.0f && dest[0].z() == 30.0f &&
-      dest[0].w() == 40.0f) {
+  cl::sycl::float4 expected = {10.f, 20.f, 30.f, 40.f};
+  if (cl::sycl::all(cl::sycl::isequal(dest[0], expected))) {
     std::cout << "The output image is as expected." << std::endl;
     return 0;
   } else {

--- a/samples/simple-example-of-vectors/simple-example-of-vectors.cpp
+++ b/samples/simple-example-of-vectors/simple-example-of-vectors.cpp
@@ -88,7 +88,7 @@ int main() {
   }
 
   for (int i = 0; i < size; i++) {
-    if (dataB[i].y() != static_cast<float>(i)) {
+    if (static_cast<float>(dataB[i].y()) != i) {
       ret = -1;
     }
   }

--- a/samples/simple-private-memory/simple-private-memory.cpp
+++ b/samples/simple-private-memory/simple-private-memory.cpp
@@ -78,12 +78,12 @@ int main() {
          * per work-item and lives in work-item-private memory. */
         private_memory<int> privateObj(groupID);
 
-        groupID.parallel_for_work_item([&](item<1> itemID) {
+        groupID.parallel_for_work_item([&](h_item<1> itemID) {
           /* Assign the work-item global id into private memory. */
-          privateObj(itemID) = get_global_id(groupID, itemID)[0];
+          privateObj(itemID) = itemID.get_global_id()[0];
         });
 
-        groupID.parallel_for_work_item([&](item<1> itemID) {
+        groupID.parallel_for_work_item([&](h_item<1> itemID) {
           /* Retrieve the global id stored in the previous
            * parallel_for_work_item call and store it in global memory. */
           auto globalID = privateObj(itemID);


### PR DESCRIPTION
The hierarchical samples now have the required h_item. Other samples
have had updates to their vector code, as single-element swizzles now
return 1-d vectors, not scalars, so require some coercing.

Additionally the travis config was slightly updated again, hopefully
to be even more robust with regards to the new ComputeCpp version.