### PR TITLE
Update SDK to ComputeCpp v0.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,6 @@ script:
     ###########################
     - mkdir build
     - cd build
-    - cmake ../ -DComputeCpp_DIR=/tmp/computecpp -DCOMPUTECPP_SDK_BUILD_TESTS=1 -DCMAKE_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=0"
+    - LD_LIBRARY_PATH=/tmp/OpenCL-ICD-Loader/build/lib cmake ../ -DComputeCpp_DIR=/tmp/computecpp -DCOMPUTECPP_SDK_BUILD_TESTS=1 -DCMAKE_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=0"
     - make -j2
     - COMPUTECPP_TARGET="host" ctest -V

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -6,3 +6,11 @@ sudo apt-get update -q
 sudo apt-get install ocl-icd-libopencl1 ocl-icd-dev opencl-headers -y
 # Use gcc 5 as default
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5
+cd /tmp
+git clone https://github.com/KhronosGroup/OpenCL-ICD-Loader
+cd OpenCL-ICD-Loader/inc
+git clone https://github.com/KhronosGroup/OpenCL-Headers
+cd ../
+mkdir -p build && cd build
+cmake ../ -DCMAKE_BUILD_TYPE=Release
+make -j2

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -8,9 +8,8 @@ sudo apt-get install ocl-icd-libopencl1 ocl-icd-dev opencl-headers -y
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5
 cd /tmp
 git clone https://github.com/KhronosGroup/OpenCL-ICD-Loader
-cd OpenCL-ICD-Loader/inc
-git clone https://github.com/KhronosGroup/OpenCL-Headers
-cd ../
+cd OpenCL-ICD-Loader
+git clone https://github.com/KhronosGroup/OpenCL-Headers inc
 mkdir -p build && cd build
 cmake ../ -DCMAKE_BUILD_TYPE=Release
 make -j2

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -9,6 +9,7 @@ sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 --slave /u
 cd /tmp
 git clone https://github.com/KhronosGroup/OpenCL-ICD-Loader
 cd OpenCL-ICD-Loader
+rm inc/README.txt
 git clone https://github.com/KhronosGroup/OpenCL-Headers inc
 mkdir -p build && cd build
 cmake ../ -DCMAKE_BUILD_TYPE=Release

--- a/.travis/build_computecpp.sh
+++ b/.travis/build_computecpp.sh
@@ -3,7 +3,7 @@
 set -ev
 
 # Get ComputeCpp
-wget --no-check-certificate https://computecpp.codeplay.com/downloads/computecpp-ce/0.8.0/ubuntu-14.04-64bit.tar.gz
+wget --no-check-certificate https://computecpp.codeplay.com/downloads/computecpp-ce/0.9.0/ubuntu-14.04-64bit.tar.gz
 mkdir -p /tmp/computecpp
 tar -xzf ubuntu-14.04-64bit.tar.gz -C /tmp/computecpp --strip-components=1
 # Workaround for C99 definition conflict

--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -84,7 +84,7 @@ find_library(COMPUTECPP_RUNTIME_LIBRARY
   DOC "ComputeCpp Runtime Library")
 
 find_library(COMPUTECPP_RUNTIME_LIBRARY_DEBUG
-  NAMES ComputeCpp ComputeCpp_vs2015_d
+  NAMES ComputeCpp ComputeCpp_vs2015
   PATHS ${ComputeCpp_ROOT_DIR}
   PATH_SUFFIXES lib
   DOC "ComputeCpp Debug Runtime Library")
@@ -146,6 +146,13 @@ mark_as_advanced(ComputeCpp_ROOT_DIR
 
 if(NOT ComputeCpp_FOUND)
   return()
+endif()
+
+if(MSVC)
+  message(WARNING "    The Debug ComputeCpp library is missing! You might
+    experience linker errors or crashes when building a Debug
+    configuration. Please file an issue on Github if you do.
+    This will be fixed in a subsequent release.")
 endif()
 
 if(CMAKE_CROSSCOMPILING)


### PR DESCRIPTION
Obviously, the Travis change. Slightly less obviously, the debug
build of ComputeCpp for Windows (which links against the debug CRT)
is missing from the package. If you are building on Windows, you
might get link errors for debug builds, or possibly even runtime
crashes. If you do run into any errors, please let us know. It will
be fixed in a subsequent release.