### PR TITLE
Replace target_link_libraries with set_property

### DIFF
--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -417,7 +417,8 @@ function(add_sycl_to_target)
     )
     MATH(EXPR fileCounter "${fileCounter} + 1")
   endforeach()
-  set_target_properties(${SDK_ADD_SYCL_TARGET} PROPERTIES
-    INTERFACE_LINK_LIBRARIES ComputeCpp::ComputeCpp
-    LINK_LIBRARIES ComputeCpp::ComputeCpp)
+  set_property(TARGET ${SDK_ADD_SYCL_TARGET}
+    APPEND PROPERTY LINK_LIBRARIES ComputeCpp::ComputeCpp)
+  set_property(TARGET ${SDK_ADD_SYCL_TARGET}
+    APPEND PROPERTY INTERFACE_LINK_LIBRARIES ComputeCpp::ComputeCpp)
 endfunction(add_sycl_to_target)

--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -417,7 +417,7 @@ function(add_sycl_to_target)
     )
     MATH(EXPR fileCounter "${fileCounter} + 1")
   endforeach()
-  target_link_libraries(${SDK_ADD_SYCL_TARGET}
-    PUBLIC ComputeCpp::ComputeCpp
-  )
+  set_target_properties(${SDK_ADD_SYCL_TARGET} PROPERTIES
+    INTERFACE_LINK_LIBRARIES ComputeCpp::ComputeCpp
+    LINK_LIBRARIES ComputeCpp::ComputeCpp)
 endfunction(add_sycl_to_target)


### PR DESCRIPTION
This is to support `target_link_libraries` with and without the `PRIVATE/PUBLIC/INTERFACE` keywords.

Closes #136.