### PR TITLE
Remove -isystem from device compiler command

### DIFF
--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -295,7 +295,6 @@ function(__build_ir)
     OUTPUT ${outputSyclFile}
     COMMAND ${ComputeCpp_DEVICE_COMPILER_EXECUTABLE}
             ${COMPUTECPP_DEVICE_COMPILER_FLAGS}
-            -isystem ${ComputeCpp_INCLUDE_DIRS}
             ${device_compiler_includes}
             ${generated_include_directories}
             ${generated_compile_definitions}


### PR DESCRIPTION
This was causing issues if you installed ComputeCpp to a system
directory (like /usr). It was necessary in old code, but isn't
needed any more since we get all includes from the target that is
being compiled.