### PR TITLE
Simplify cross compilation with ComputeCpp_HOST_DIR

### DIFF
--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -65,12 +65,23 @@ elseif(DEFINED ENV{COMPUTECPP_DIR})
   set(computecpp_find_hint $ENV{COMPUTECPP_DIR})
 endif()
 
+if(CMAKE_CROSSCOMPILING)
+  # ComputeCpp_NATIVE_DIR is used to find executables that are run locally
+  if(DEFINED ComputeCpp_NATIVE_DIR)
+    set(computecpp_native_find_hint ${ComputeCpp_NATIVE_DIR})
+  elseif(DEFINED ENV{COMPUTECPP_NATIVE_DIR})
+    set(computecpp_native_find_hint $ENV{COMPUTECPP_NATIVE_DIR})
+  else()
+    set(computecpp_native_find_hint ${computecpp_find_hint})
+  endif()
+endif()
+
 find_program(ComputeCpp_DEVICE_COMPILER_EXECUTABLE compute++
-  PATHS ${computecpp_find_hint}
+  PATHS ${computecpp_native_find_hint}
   PATH_SUFFIXES bin)
 
 find_program(ComputeCpp_INFO_EXECUTABLE computecpp_info
-  PATHS ${computecpp_find_hint}
+  PATHS ${computecpp_native_find_hint}
   PATH_SUFFIXES bin)
 
 find_library(COMPUTECPP_RUNTIME_LIBRARY

--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -58,7 +58,6 @@ find_package(OpenCL REQUIRED)
 
 # Find ComputeCpp package
 
-# Try to read the environment variable
 if(DEFINED ComputeCpp_DIR)
   set(computecpp_find_hint ${ComputeCpp_DIR})
 elseif(DEFINED ENV{COMPUTECPP_DIR})

--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -64,14 +64,15 @@ elseif(DEFINED ENV{COMPUTECPP_DIR})
   set(computecpp_find_hint $ENV{COMPUTECPP_DIR})
 endif()
 
+# Used for running executables locally
+set(computecpp_native_find_hint ${computecpp_find_hint})
+
 if(CMAKE_CROSSCOMPILING)
   # ComputeCpp_NATIVE_DIR is used to find executables that are run locally
   if(DEFINED ComputeCpp_NATIVE_DIR)
     set(computecpp_native_find_hint ${ComputeCpp_NATIVE_DIR})
   elseif(DEFINED ENV{COMPUTECPP_NATIVE_DIR})
     set(computecpp_native_find_hint $ENV{COMPUTECPP_NATIVE_DIR})
-  else()
-    set(computecpp_native_find_hint ${computecpp_find_hint})
   endif()
 endif()
 

--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -64,24 +64,24 @@ elseif(DEFINED ENV{COMPUTECPP_DIR})
   set(computecpp_find_hint $ENV{COMPUTECPP_DIR})
 endif()
 
-# Used for running executables locally
-set(computecpp_native_find_hint ${computecpp_find_hint})
+# Used for running executables on the host
+set(computecpp_host_find_hint ${computecpp_find_hint})
 
 if(CMAKE_CROSSCOMPILING)
-  # ComputeCpp_NATIVE_DIR is used to find executables that are run locally
-  if(DEFINED ComputeCpp_NATIVE_DIR)
-    set(computecpp_native_find_hint ${ComputeCpp_NATIVE_DIR})
-  elseif(DEFINED ENV{COMPUTECPP_NATIVE_DIR})
-    set(computecpp_native_find_hint $ENV{COMPUTECPP_NATIVE_DIR})
+  # ComputeCpp_HOST_DIR is used to find executables that are run on the host
+  if(DEFINED ComputeCpp_HOST_DIR)
+    set(computecpp_host_find_hint ${ComputeCpp_HOST_DIR})
+  elseif(DEFINED ENV{COMPUTECPP_HOST_DIR})
+    set(computecpp_host_find_hint $ENV{COMPUTECPP_HOST_DIR})
   endif()
 endif()
 
 find_program(ComputeCpp_DEVICE_COMPILER_EXECUTABLE compute++
-  PATHS ${computecpp_native_find_hint}
+  PATHS ${computecpp_host_find_hint}
   PATH_SUFFIXES bin)
 
 find_program(ComputeCpp_INFO_EXECUTABLE computecpp_info
-  PATHS ${computecpp_native_find_hint}
+  PATHS ${computecpp_host_find_hint}
   PATH_SUFFIXES bin)
 
 find_library(COMPUTECPP_RUNTIME_LIBRARY


### PR DESCRIPTION
Adds a CMake option `ComputeCpp_NATIVE_DIR`  that is used to specify the directory of the ComputeCpp package built for the native architecture. For example, when cross compiling for ARM on an x86 machine, `ComputeCpp_DIR` would point to the ARM package of ComputeCpp and `ComputeCpp_NATIVE_DIR` would point to the x86 one. This is required because the CMake script executes binaries from the ComputeCpp package.