### PR TITLE
Update SDK to ComputeCpp v1.0.1

### DIFF
--- a/.travis/build_computecpp.sh
+++ b/.travis/build_computecpp.sh
@@ -3,7 +3,7 @@
 set -ev
 
 # Get ComputeCpp
-wget --no-check-certificate https://computecpp.codeplay.com/downloads/computecpp-ce/1.0.0/ubuntu-14.04-64bit.tar.gz
+wget --no-check-certificate https://computecpp.codeplay.com/downloads/computecpp-ce/1.0.1/ubuntu-14.04-64bit.tar.gz
 mkdir -p /tmp/computecpp
 tar -xzf ubuntu-14.04-64bit.tar.gz -C /tmp/computecpp --strip-components=1
 # Workaround for C99 definition conflict

--- a/samples/reinterpret/reinterpret.cpp
+++ b/samples/reinterpret/reinterpret.cpp
@@ -62,11 +62,6 @@ int main() {
     });
   });
 
-  /* Workaround for known limitation in ComputeCpp, see blog post for
-   * details: https://www.codeplay.com/portal/
-   * 03-09-18-buffer-reinterpret-viewing-data-from-a-different-perspective */
-  { auto acc = buf_int.get_access<cl::sycl::access::mode::read>(); }
-
   auto ret = 0;
   {
     auto acc = buf_float.get_access<cl::sycl::access::mode::read>();


### PR DESCRIPTION
The workaround for the reinterpret feature has been removed, as it
is no longer necessary.