### PR TITLE
Add check so `end` iterator is not dereferenced

### DIFF
--- a/include/vptr/virtual_ptr.hpp
+++ b/include/vptr/virtual_ptr.hpp
@@ -219,7 +219,7 @@ class PointerMapper {
     auto node = m_pointerMap.lower_bound(ptr);
     // If the value of the pointer is not the one of the node
     // then we return the previous one
-    if (node->first != ptr) {
+    if (node == m_pointerMap.end() || node->first != ptr) {
       if (node == std::begin(m_pointerMap)) {
         throw std::out_of_range("The pointer is not registered in the map");
       }


### PR DESCRIPTION
The current behaviour of `get_node` in the virtual pointer mapper will
use `lower_bound` to get the buffer which is not less than the input
pointer. If the pointer mapper has only allocated one buffer, and we are
looking up a pointer offset into that buffer then the call to
`lower_bound` will return an iterator pointing past the end of the map.
This means we cannot dereference this iterator, as it does not point
into the map, but we still want to decrement this iterator to get the
buffer that the virtual pointer is referencing.

By adding a check for whether the iterator is the end we can short
circuit the iterator dereference, and so avoid this problem without
otherwise changing the behaviour of the pointer mapper.