### PR TITLE
Fix accessor tests, and add property_list parameter to syclmalloc

### DIFF
--- a/include/vptr/virtual_ptr.hpp
+++ b/include/vptr/virtual_ptr.hpp
@@ -500,13 +500,13 @@ inline void PointerMapper::remove_pointer<false>(const virtual_pointer_t ptr) {
  * \param size Size in bytes of the desired allocation
  * \throw cl::sycl::exception if error while creating the buffer
  */
-inline void* SYCLmalloc(size_t size, PointerMapper& pMap) {
+inline void* SYCLmalloc(size_t size, PointerMapper& pMap, const property_list &pList = {}) {
   if (size == 0) {
     return nullptr;
   }
   // Create a generic buffer of the given size
   using sycl_buffer_t = cl::sycl::buffer<buffer_data_type_t, 1>;
-  auto thePointer = pMap.add_pointer(sycl_buffer_t(cl::sycl::range<1>{size}));
+  auto thePointer = pMap.add_pointer(sycl_buffer_t(cl::sycl::range<1>{size}, pList));
   // Store the buffer on the global list
   return static_cast<void*>(thePointer);
 }

--- a/tests/vptr/accessor.cc
+++ b/tests/vptr/accessor.cc
@@ -121,9 +121,8 @@ TEST(accessor, two_buffers) {
   }
 }
 
+// Is this test still required, given that we no longer use allocators?
 TEST(accessor, allocator) {
-  // an allocator type
-  using alloc_t = cl::sycl::buffer_allocator<uint8_t>;
 
   PointerMapper pMap;
   {
@@ -138,10 +137,10 @@ TEST(accessor, allocator) {
     ASSERT_EQ(pMap.count(), 1u);
 
     // add a pointer with the allocator type
-    void* ptrB = SYCLmalloc<alloc_t>(100 * sizeof(int), pMap);
+    void* ptrB = SYCLmalloc(100 * sizeof(int), pMap);
 
     // get the buffer with the allocator type
-    cl::sycl::buffer<uint8_t, 1, alloc_t> bufB = pMap.get_buffer<alloc_t>(ptrB);
+    cl::sycl::buffer<uint8_t, 1> bufB = pMap.get_buffer(ptrB);
 
     ASSERT_EQ(pMap.count(), 2u);
   }

--- a/tests/vptr/accessor.cc
+++ b/tests/vptr/accessor.cc
@@ -121,27 +121,3 @@ TEST(accessor, two_buffers) {
   }
 }
 
-// Is this test still required, given that we no longer use allocators?
-TEST(accessor, allocator) {
-
-  PointerMapper pMap;
-  {
-    ASSERT_EQ(pMap.count(), 0u);
-
-    // add a pointer with the base allocator type
-    void* ptrA = SYCLmalloc(100 * sizeof(int), pMap);
-
-    // get the buffer with the base allocator type
-    auto bufA = pMap.get_buffer(ptrA);
-
-    ASSERT_EQ(pMap.count(), 1u);
-
-    // add a pointer with the allocator type
-    void* ptrB = SYCLmalloc(100 * sizeof(int), pMap);
-
-    // get the buffer with the allocator type
-    cl::sycl::buffer<uint8_t, 1> bufB = pMap.get_buffer(ptrB);
-
-    ASSERT_EQ(pMap.count(), 2u);
-  }
-}


### PR DESCRIPTION
This PR fixes a test that was forgotten when travis broke, and adds a `parameter_list` argument to syclmalloc so that we can control allocation (e.g. `use_host_ptr`, `context_bound` etc).