### PR TITLE
Move compiler checks to separate module

### DIFF
--- a/cmake/Modules/ComputeCppCompilerChecks.cmake
+++ b/cmake/Modules/ComputeCppCompilerChecks.cmake
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.4.3)
+
+if(CMAKE_COMPILER_IS_GNUCXX)
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
+    message(FATAL_ERROR "host compiler - gcc version must be > 4.8")
+  endif()
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  if (${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 3.6)
+    message(FATAL_ERROR "host compiler - clang version must be > 3.6")
+  endif()
+endif()
+
+if(MSVC)
+  set(ComputeCpp_STL_CHECK_SRC __STL_check)
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${ComputeCpp_STL_CHECK_SRC}.cpp
+    "#include <ios>\n"
+    "int main() { return 0; }\n")
+  execute_process(
+    COMMAND ${ComputeCpp_DEVICE_COMPILER_EXECUTABLE}
+            ${COMPUTECPP_DEVICE_COMPILER_FLAGS}
+            -isystem ${ComputeCpp_INCLUDE_DIRS}
+            -o ${ComputeCpp_STL_CHECK_SRC}.sycl
+            -c ${ComputeCpp_STL_CHECK_SRC}.cpp
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    RESULT_VARIABLE ComputeCpp_STL_CHECK_RESULT
+    ERROR_QUIET
+    OUTPUT_QUIET)
+  if(NOT ${ComputeCpp_STL_CHECK_RESULT} EQUAL 0)
+    # Try disabling compiler version checks
+    execute_process(
+      COMMAND ${ComputeCpp_DEVICE_COMPILER_EXECUTABLE}
+              ${COMPUTECPP_DEVICE_COMPILER_FLAGS}
+              -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
+              -isystem ${ComputeCpp_INCLUDE_DIRS}
+              -o ${ComputeCpp_STL_CHECK_SRC}.cpp.sycl
+              -c ${ComputeCpp_STL_CHECK_SRC}.cpp
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+      RESULT_VARIABLE ComputeCpp_STL_CHECK_RESULT
+      ERROR_QUIET
+      OUTPUT_QUIET)
+    if(NOT ${ComputeCpp_STL_CHECK_RESULT} EQUAL 0)
+      message(STATUS "Device compiler cannot consume hosted STL headers. Using any parts of the STL will likely result in device compiler errors.")
+    else()
+    message(STATUS "Device compiler does not meet certain STL version requirements. Disabling version checks and hoping for the best.")
+      list(APPEND COMPUTECPP_DEVICE_COMPILER_FLAGS -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH)
+    endif()
+  endif()
+  file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/${ComputeCpp_STL_CHECK_SRC}.cpp
+              ${CMAKE_CURRENT_BINARY_DIR}/${ComputeCpp_STL_CHECK_SRC}.cpp.sycl)
+endif(MSVC)

--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -32,21 +32,6 @@
 cmake_minimum_required(VERSION 3.4.3)
 include(FindPackageHandleStandardArgs)
 
-# Check that a supported host compiler can be found
-if(CMAKE_COMPILER_IS_GNUCXX)
-    # Require at least gcc 4.8
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
-      message(FATAL_ERROR
-        "host compiler - gcc version must be at least 4.8")
-    endif()
-elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    # Require at least clang 3.6
-    if (${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 3.6)
-      message(FATAL_ERROR
-        "host compiler - clang version must be at least 3.6")
-    endif()
-endif()
-
 set(COMPUTECPP_USER_FLAGS "" CACHE STRING "User flags for compute++")
 mark_as_advanced(COMPUTECPP_USER_FLAGS)
 
@@ -137,46 +122,6 @@ if(NOT ComputeCpp_INFO_EXECUTABLE_RESULT EQUAL "0")
 endif()
 mark_as_advanced(COMPUTECPP_DEVICE_COMPILER_FLAGS)
 separate_arguments(COMPUTECPP_DEVICE_COMPILER_FLAGS)
-
-# Check if the hosted STL of MSVC is compatible with ComputeCpp
-if(MSVC)
-  set(ComputeCpp_STL_CHECK_SRC __STL_check)
-  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${ComputeCpp_STL_CHECK_SRC}.cpp
-    "#include <ios>\n"
-	"int main() { return 0; }\n")
-  execute_process(
-    COMMAND ${ComputeCpp_DEVICE_COMPILER_EXECUTABLE}
-            ${COMPUTECPP_DEVICE_COMPILER_FLAGS}
-            -isystem ${ComputeCpp_INCLUDE_DIRS}
-            -o ${ComputeCpp_STL_CHECK_SRC}.sycl
-            -c ${ComputeCpp_STL_CHECK_SRC}.cpp
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    RESULT_VARIABLE ComputeCpp_STL_CHECK_RESULT
-    ERROR_QUIET
-    OUTPUT_QUIET)
-  if(NOT ${ComputeCpp_STL_CHECK_RESULT} EQUAL 0)
-    # Try disabling compiler version checks
-    execute_process(
-      COMMAND ${ComputeCpp_DEVICE_COMPILER_EXECUTABLE}
-              ${COMPUTECPP_DEVICE_COMPILER_FLAGS}
-              -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
-              -isystem ${ComputeCpp_INCLUDE_DIRS}
-              -o ${ComputeCpp_STL_CHECK_SRC}.cpp.sycl
-              -c ${ComputeCpp_STL_CHECK_SRC}.cpp
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-      RESULT_VARIABLE ComputeCpp_STL_CHECK_RESULT
-      ERROR_QUIET
-      OUTPUT_QUIET)
-    if(NOT ${ComputeCpp_STL_CHECK_RESULT} EQUAL 0)
-      message(STATUS "Device compiler cannot consume hosted STL headers. Using any parts of the STL will likely result in device compiler errors.")
-    else()
-	  message(STATUS "Device compiler does not meet certain STL version requirements. Disabling version checks and hoping for the best.")
-      list(APPEND COMPUTECPP_DEVICE_COMPILER_FLAGS -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH)
-    endif()
-  endif()
-  file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/${ComputeCpp_STL_CHECK_SRC}.cpp
-              ${CMAKE_CURRENT_BINARY_DIR}/${ComputeCpp_STL_CHECK_SRC}.cpp.sycl)
-endif(MSVC)
 
 find_package_handle_standard_args(ComputeCpp
   REQUIRED_VARS ComputeCpp_ROOT_DIR
@@ -412,7 +357,7 @@ function(__build_ir)
     # Add both source and the sycl files to the VS solution.
     target_sources(${SDK_BUILD_IR_TARGET} PUBLIC ${SDK_BUILD_IR_SOURCE} ${outputSyclFile})
 
-    set(forceIncludeFlags "/FI ${includedFile} /TP")
+    set(forceIncludeFlags "/FI${includedFile} /TP")
   else()
     set(forceIncludeFlags "-include ${includedFile} -x c++")
   endif()


### PR DESCRIPTION
Moving these compiler checks to a separate module keeps the main
FindComputeCpp.cmake clean and makes the checks "opt-in", if you
know that you won't need the check for your project.

@MathiasMagnus @ProGTX I'd appreciate if you could look at this!
Should fix #159 