### PR TITLE
Various CMake improvements

### DIFF
--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -243,13 +243,10 @@ function(__build_ir)
 
   set(include_directories "$<TARGET_PROPERTY:${SDK_BUILD_IR_TARGET},INCLUDE_DIRECTORIES>")
   set(compile_definitions "$<TARGET_PROPERTY:${SDK_BUILD_IR_TARGET},COMPILE_DEFINITIONS>")
-  set(compile_options "$<TARGET_PROPERTY:${SDK_BUILD_IR_TARGET},COMPILE_OPTIONS>")
   set(generated_include_directories
     $<$<BOOL:${include_directories}>:-I\"$<JOIN:${include_directories},\"\t-I\">\">)
   set(generated_compile_definitions
     $<$<BOOL:${compile_definitions}>:-D$<JOIN:${compile_definitions},\t-D>>)
-  set(generated_compile_options
-    $<$<BOOL:${compile_options}>:$<JOIN:${compile_options},\t>>)
 
   # Obtain language standard of the file
   set(device_compiler_cxx_standard)
@@ -303,7 +300,6 @@ function(__build_ir)
     OUTPUT ${outputSyclFile}
     COMMAND ${ComputeCpp_DEVICE_COMPILER_EXECUTABLE}
             ${COMPUTECPP_DEVICE_COMPILER_FLAGS}
-            ${generated_compile_options}
             ${generated_include_directories}
             ${generated_compile_definitions}
             -o ${outputSyclFile}

--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -266,19 +266,20 @@ function(__build_ir)
     set(device_compiler_cxx_standard "")
   endif()
 
-  list(APPEND COMPUTECPP_DEVICE_COMPILER_FLAGS
-    ${device_compiler_cxx_standard}
-    ${COMPUTECPP_USER_FLAGS}
-  )
-
   get_property(source_compile_flags
     SOURCE ${SDK_BUILD_IR_SOURCE}
     PROPERTY COMPUTECPP_SOURCE_FLAGS
   )
   separate_arguments(source_compile_flags)
   if(source_compile_flags)
-    list(APPEND COMPUTECPP_DEVICE_COMPILER_FLAGS ${source_compile_flags})
+    list(APPEND computecpp_source_flags ${source_compile_flags})
   endif()
+
+  list(APPEND COMPUTECPP_DEVICE_COMPILER_FLAGS
+    ${device_compiler_cxx_standard}
+    ${COMPUTECPP_USER_FLAGS}
+    ${computecpp_source_flags}
+  )
 
   set(ir_dependencies ${SDK_BUILD_IR_SOURCE})
   get_target_property(target_libraries ${SDK_BUILD_IR_TARGET} LINK_LIBRARIES)

--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -243,13 +243,13 @@ function(__build_ir)
 
   set(include_directories "$<TARGET_PROPERTY:${SDK_BUILD_IR_TARGET},INCLUDE_DIRECTORIES>")
   set(compile_definitions "$<TARGET_PROPERTY:${SDK_BUILD_IR_TARGET},COMPILE_DEFINITIONS>")
-  set(compile_flags "$<TARGET_PROPERTY:${SDK_BUILD_IR_TARGET},COMPILE_OPTIONS>")
+  set(compile_options "$<TARGET_PROPERTY:${SDK_BUILD_IR_TARGET},COMPILE_OPTIONS>")
   set(generated_include_directories
     $<$<BOOL:${include_directories}>:-I\"$<JOIN:${include_directories},\"\t-I\">\">)
   set(generated_compile_definitions
     $<$<BOOL:${compile_definitions}>:-D$<JOIN:${compile_definitions},\t-D>>)
-  set(generated_compile_flags
-    $<$<BOOL:${compile_flags}>:$<JOIN:${compile_flags},\t>>)
+  set(generated_compile_options
+    $<$<BOOL:${compile_options}>:$<JOIN:${compile_options},\t>>)
 
   # Obtain language standard of the file
   set(device_compiler_cxx_standard)
@@ -302,7 +302,7 @@ function(__build_ir)
     OUTPUT ${outputSyclFile}
     COMMAND ${ComputeCpp_DEVICE_COMPILER_EXECUTABLE}
             ${COMPUTECPP_DEVICE_COMPILER_FLAGS}
-            ${generated_compile_flags}
+            ${generated_compile_options}
             ${generated_include_directories}
             ${generated_compile_definitions}
             -o ${outputSyclFile}


### PR DESCRIPTION
Various changes mostly needed by Eigen:
- fix issue if multiple targets use the same source file
- ~take into account arguments from the `COMPILE_FLAGS` target property~ Removed as it may break the compiler if some flags are meant for a different host compiler only (i.e. gcc)
- call separate_arguments on `COMPUTECPP_USER_FLAGS` as the user should just be able to give space separated string
- remove unused `device_compiler_includes` variable