### PR TITLE
Fix non forward declarable SYCL kernel names

### DIFF
--- a/samples/accessors/accessors.cpp
+++ b/samples/accessors/accessors.cpp
@@ -32,6 +32,8 @@
 
 using namespace cl::sycl;
 
+class multiply;
+
 int main() {
   /* We define the data to be passed to the device. */
   int data = 5;
@@ -59,7 +61,7 @@ int main() {
        * to access::mode::global) */
       auto ptr = buf.get_access<access::mode::read_write>(cgh);
 
-      cgh.single_task<class multiply>([=]() {
+      cgh.single_task<multiply>([=]() {
         /* We use the subscript operator of the accessor constructed above to
          * read the value, multiply it by itself and then write it back to the
          * accessor again. */

--- a/samples/async-handler/async-handler.cpp
+++ b/samples/async-handler/async-handler.cpp
@@ -44,6 +44,8 @@ using namespace cl::sycl;
  *
  *  The expected outcome of the sample code is to trigger the
  *  asynchronous handler a number of times. */
+class kernel0;
+
 int main() {
   bool error = false;
   unsigned nTimesCall = 0;
@@ -90,7 +92,7 @@ int main() {
   auto cgh_error = [&](handler& cgh) {
     auto myRange = nd_range<2>(range<2>(6, 2), range<2>(20000, 20000));
 
-    cgh.parallel_for<class kernel0>(myRange, [=](nd_item<2> itemID) {});
+    cgh.parallel_for<kernel0>(myRange, [=](nd_item<2> itemID) {});
   };
 
   default_selector mySelector;

--- a/samples/custom-device-selector/custom-device-selector.cpp
+++ b/samples/custom-device-selector/custom-device-selector.cpp
@@ -29,6 +29,8 @@
 
 using namespace cl::sycl;
 
+class example_kernel;
+
 /* Classes can inherit from the device_selector class to allow users
  * to dictate the criteria for choosing a device from those that might be
  * present on a system. This example looks for a device with SPIR support
@@ -74,7 +76,7 @@ int main() {
   myQueue.submit([&](handler& cgh) {
     auto ptr = buf.get_access<access::mode::read_write>(cgh);
 
-    cgh.parallel_for<class example_kernel>(dataRange, [=](item<1> item) {
+    cgh.parallel_for<example_kernel>(dataRange, [=](item<1> item) {
       size_t idx = item.get_linear_id();
       ptr[item.get_linear_id()] = static_cast<float>(idx);
     });

--- a/samples/example-sycl-application/example-sycl-application.cpp
+++ b/samples/example-sycl-application/example-sycl-application.cpp
@@ -35,6 +35,10 @@ using namespace cl::sycl;
 const size_t N = 100;
 const size_t M = 150;
 
+class init_a;
+class init_b;
+class matrix_add;
+
 /* This sample creates three device-only arrays, then initialises them
  * on the device. After that, it adds two of them together, storing the
  * result in the third buffer. It then verifies the result of the kernel
@@ -54,7 +58,7 @@ int main() {
      * write access. */
     myQueue.submit([&](handler& cgh) {
       auto A = a.get_access<access::mode::write>(cgh);
-      cgh.parallel_for<class init_a>(range<2>{N, M}, [=](id<2> index) {
+      cgh.parallel_for<init_a>(range<2>{N, M}, [=](id<2> index) {
         A[index] = index[0] * 2 + index[1];
       });
     });
@@ -66,7 +70,7 @@ int main() {
      * to the device with no dependencies between each other. */
     myQueue.submit([&](handler& cgh) {
       auto B = b.get_access<access::mode::write>(cgh);
-      cgh.parallel_for<class init_b>(range<2>{N, M}, [=](id<2> index) {
+      cgh.parallel_for<init_b>(range<2>{N, M}, [=](id<2> index) {
         B[index] = index[0] * 2014 + index[1] * 42;
       });
     });
@@ -81,7 +85,7 @@ int main() {
       auto A = a.get_access<access::mode::read>(cgh);
       auto B = b.get_access<access::mode::read>(cgh);
       auto C = c.get_access<access::mode::write>(cgh);
-      cgh.parallel_for<class matrix_add>(
+      cgh.parallel_for<matrix_add>(
           range<2>{N, M}, [=](id<2> index) { C[index] = A[index] + B[index]; });
     });
 

--- a/samples/gaussian-blur/gaussian-blur.cpp
+++ b/samples/gaussian-blur/gaussian-blur.cpp
@@ -42,6 +42,9 @@ typedef unsigned int uint;
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"
 
+class fillGaussian;
+class GaussianKernel;
+
 using namespace cl::sycl;
 /* It is possible to refer to the enum name in these using statements, used
  * here to make referencing the members more convenient (for example). */
@@ -129,7 +132,7 @@ int main(int argc, char* argv[]) {
     myQueue.submit([&](cl::sycl::handler& cgh) {
       auto globalGaussian =
           gaussian.get_access<access::mode::discard_write>(cgh);
-      cgh.parallel_for<class fillGaussian>(
+      cgh.parallel_for<fillGaussian>(
           gaussianRange, [=](cl::sycl::item<2> i) {
             auto x = i[0] - 3 * stddev, y = i[1] - 3 * stddev;
             auto elem =
@@ -164,7 +167,7 @@ int main(int argc, char* argv[]) {
       sampler smpl(coordinate_normalization_mode::unnormalized,
                    addressing_mode::clamp, filtering_mode::nearest);
 
-      cgh.parallel_for<class GaussianKernel>(myRange, [=](nd_item<2> itemID) {
+      cgh.parallel_for<GaussianKernel>(myRange, [=](nd_item<2> itemID) {
         float4 newPixel = float4(0.0f, 0.0f, 0.0f, 0.0f);
         constexpr auto offset = 3 * stddev;
 

--- a/samples/hello-world/hello-world.cpp
+++ b/samples/hello-world/hello-world.cpp
@@ -29,6 +29,8 @@
 
 #include <iostream>
 
+class hello_world;
+
 /* This is a basic example to illustrate the main components of a SYCL
  * program. It executes a single-threaded kernel on the default device
  * (as determined by the SYCL implementation) whose only function is to
@@ -64,7 +66,7 @@ int main() {
      * lambda. The template parameter needs to be a unique name that
      * the runtime can use to identify the kernel (since lambdas have
      * no accessible name). */
-    cgh.single_task<class hello_world>([=]() {
+    cgh.single_task<hello_world>([=]() {
       /* We use the stream operator on the stream object we created above
        * to print to stdout from the device. */
       os << "Hello, World!\n";

--- a/samples/images/images.cpp
+++ b/samples/images/images.cpp
@@ -31,6 +31,8 @@
 
 using namespace cl::sycl;
 
+class mod_image;
+
 int main() {
   /* We define and populate arrays for the input and output data. */
   float4 src[256];
@@ -80,7 +82,7 @@ int main() {
       sampler smpl(coordinate_normalization_mode::unnormalized,
                    addressing_mode::clamp, filtering_mode::nearest);
 
-      cgh.parallel_for<class mod_image>(range<2>(16, 16), [=](item<2> item) {
+      cgh.parallel_for<mod_image>(range<2>(16, 16), [=](item<2> item) {
         /* SYCL vectors are used to specify the location of the image to
          * access. */
         auto coords = int2(item[0], item[1]);

--- a/samples/matrix-multiply/matrix-multiply.cpp
+++ b/samples/matrix-multiply/matrix-multiply.cpp
@@ -40,6 +40,8 @@
 
 using namespace cl::sycl;
 
+class mxm_kernel;
+
 void display_matrix(float* m, int matSize) {
   if (matSize > 16) {
     return;
@@ -162,7 +164,7 @@ bool local_mxm(cl::sycl::queue& q, T* MA, T* MB, T* MC, int matSize) {
       accessor<T, 1, access::mode::read_write, access::target::local> pBB(
           localRange, cgh);
 
-      cgh.parallel_for<class mxm_kernel>(
+      cgh.parallel_for<mxm_kernel>(
           nd_range<2>{range<2>(matSize, matSize),
                       range<2>(blockSize, blockSize)},
           [=](nd_item<2> it) {

--- a/samples/opencl-c-interop/opencl-c-interop.cpp
+++ b/samples/opencl-c-interop/opencl-c-interop.cpp
@@ -33,6 +33,8 @@
 
 using namespace cl::sycl;
 
+class pow_comp;
+
 /* The source of the OpenCL C kernel is stored in C strings as usual.
  * It is convenient to use C++11 raw string literals to store OpenCL C
  * source inside your code, as everything between the delimiters (here

--- a/samples/parallel-for/parallel-for.cpp
+++ b/samples/parallel-for/parallel-for.cpp
@@ -34,6 +34,8 @@ using namespace cl::sycl;
 /* We define the number of work items to enqueue. */
 const int nElems = 64u;
 
+class assign_elements;
+
 int main() {
   /* We define and initialize data to be copied to the device. */
   int data[nElems] = {0};
@@ -82,7 +84,7 @@ int main() {
        * we constructed above and the lambda that we constructed. Because
        * the kernel is a lambda we *must* specify a template parameter to
        * use as a name. */
-      cgh.parallel_for<class assign_elements>(myRange, myKernel);
+      cgh.parallel_for<assign_elements>(myRange, myKernel);
     });
 
   } catch (const exception& e) {

--- a/samples/reduction/reduction.cpp
+++ b/samples/reduction/reduction.cpp
@@ -33,6 +33,9 @@
 #include <random>
 #include <vector>
 
+template <typename T>
+class sycl_reduction;
+
 /* Implements a reduction of an STL vector using SYCL.
  * The input vector is not modified. */
 template <typename T>
@@ -89,7 +92,7 @@ T sycl_reduce(const std::vector<T>& v) {
 
           /* The parallel_for invocation chosen is the variant with an nd_item
            * parameter, since the code requires barriers for correctness. */
-          h.parallel_for<class sycl_reduction>(
+          h.parallel_for<sycl_reduction<T>>(
               r, [aI, scratch, local, length](cl::sycl::nd_item<1> id) {
                 size_t globalid = id.get_global_id(0);
                 size_t localid = id.get_local_id(0);

--- a/samples/reinterpret/reinterpret.cpp
+++ b/samples/reinterpret/reinterpret.cpp
@@ -27,6 +27,8 @@
 
 #include <CL/sycl.hpp>
 
+class mult;
+
 int main() {
   cl::sycl::range<1> r(128);
   cl::sycl::buffer<float, 1> buf_float(r);
@@ -51,7 +53,7 @@ int main() {
     auto acc = buf_int.get_access<cl::sycl::access::mode::read_write>(cgh);
     /* This kernel will multiply IEEE-754 32-bit floats by two, by manipulating
      * the exponent directly */
-    cgh.parallel_for<class mult>(r, [=](cl::sycl::item<2> i) {
+    cgh.parallel_for<mult>(r, [=](cl::sycl::item<2> i) {
       constexpr auto mask = 0x7F800000u;
       constexpr auto mantissa_shift = 23u;
       auto& elem = acc[i];

--- a/samples/simple-example-of-vectors/simple-example-of-vectors.cpp
+++ b/samples/simple-example-of-vectors/simple-example-of-vectors.cpp
@@ -31,6 +31,8 @@
 
 using namespace cl::sycl;
 
+class vector_example;
+
 int ret = 0;
 
 /* The purpose of this sample code is to demonstrate
@@ -76,14 +78,13 @@ int main() {
        *   vector
        *
        *   Vectors can also be scaled easily using operator overloads */
-      cgh.parallel_for<class vector_example>(
-          range<3>(4, 4, 4), [=](item<3> item) {
-            auto in = ptrA[item.get_linear_id()];
-            float w = in.w();
-            float3 swizzle = in.xyz();
-            float3 scaled = swizzle * w;
-            ptrB[item.get_linear_id()] = scaled;
-          });
+      cgh.parallel_for<vector_example>(range<3>(4, 4, 4), [=](item<3> item) {
+        auto in = ptrA[item.get_linear_id()];
+        float w = in.w();
+        float3 swizzle = in.xyz();
+        float3 scaled = swizzle * w;
+        ptrB[item.get_linear_id()] = scaled;
+      });
     });
   }
 

--- a/samples/simple-local-barrier/simple-local-barrier.cpp
+++ b/samples/simple-local-barrier/simple-local-barrier.cpp
@@ -33,6 +33,8 @@
 
 using namespace cl::sycl;
 
+class example_kernel;
+
 /* This sample demonstrates the usage of a local_barrier inside
  * a command group. The program creates an array with 64 integers
  * and swaps each pair. */
@@ -56,7 +58,7 @@ int main() {
                access::target::local>
           tile(range<1>(2), cgh);
 
-      cgh.parallel_for<class example_kernel>(
+      cgh.parallel_for<example_kernel>(
           nd_range<1>(range<1>(size), range<1>(2)), [=](nd_item<1> item) {
             size_t idx = item.get_global_linear_id();
             int pos = idx & 1;

--- a/samples/simple-private-memory/simple-private-memory.cpp
+++ b/samples/simple-private-memory/simple-private-memory.cpp
@@ -29,6 +29,8 @@
 
 using namespace cl::sycl;
 
+class PrivateMemory;
+
 /* Helper function to compute a globalID from a group and item in a
  * hierarchical parallel_for_work_item context */
 static inline cl::sycl::id<1> get_global_id(cl::sycl::group<1>& group,
@@ -90,8 +92,8 @@ int main() {
           ptr[globalID] = globalID;
         });
       };
-      cgh.parallel_for_work_group<class PrivateMemory>(groupRange, localRange,
-                                                       hierarchicalKernel);
+      cgh.parallel_for_work_group<PrivateMemory>(groupRange, localRange,
+                                                 hierarchicalKernel);
     });
   }
 

--- a/samples/smart-pointer/smart-pointer.cpp
+++ b/samples/smart-pointer/smart-pointer.cpp
@@ -32,6 +32,10 @@
 
 using namespace cl::sycl;
 
+class kernel0;
+class kernel1;
+class kernel2;
+
 int main() {
   const unsigned int nElems = 12;
   std::shared_ptr<int> p(new int[nElems]);
@@ -54,7 +58,7 @@ int main() {
         auto myRange = nd_range<2>(range<2>(6, 2), range<2>(2, 1));
 
         auto ptr = buf.get_access<access::mode::read_write>(cgh);
-        cgh.parallel_for<class kernel0>(myRange, [=](nd_item<2> itemID) {
+        cgh.parallel_for<kernel0>(myRange, [=](nd_item<2> itemID) {
           ptr[itemID.get_global_linear_id()] =
               (int) (itemID.get_global_linear_id());
         });
@@ -102,7 +106,7 @@ int main() {
         auto myRange = nd_range<2>(range<2>(6, 2), range<2>(2, 1));
 
         auto ptr = buf.get_access<access::mode::read_write>(cgh);
-        cgh.parallel_for<class kernel1>(myRange, [=](nd_item<2> itemID) {
+        cgh.parallel_for<kernel1>(myRange, [=](nd_item<2> itemID) {
           ptr[itemID.get_global_linear_id()] = itemID.get_global_linear_id();
         });
       });
@@ -134,7 +138,7 @@ int main() {
         auto myRange = nd_range<2>(range<2>(6, 2), range<2>(2, 1));
 
         auto ptr = buf.get_access<access::mode::read_write>(cgh);
-        cgh.parallel_for<class kernel2>(myRange, [=](nd_item<2> itemID) {
+        cgh.parallel_for<kernel2>(myRange, [=](nd_item<2> itemID) {
           ptr[itemID.get_global_linear_id()] =
               (int) (itemID.get_global_linear_id());
         });

--- a/samples/vptr/vptr.cpp
+++ b/samples/vptr/vptr.cpp
@@ -34,6 +34,10 @@
 
 using namespace cl::sycl;
 
+class init_a;
+class init_b;
+class matrix_add;
+
 const size_t N = 100;
 const size_t M = 150;
 
@@ -61,7 +65,7 @@ int main() {
     myQueue.submit([&](handler& cgh) {
       auto accA = pMap.get_access<access::mode::discard_write,
                                   access::target::global_buffer, float>(a, cgh);
-      cgh.parallel_for<class init_a>(
+      cgh.parallel_for<init_a>(
           range<1>{N * M}, [=](item<1> index) { accA[index] = index[0] * 2; });
     });
 
@@ -69,7 +73,7 @@ int main() {
     myQueue.submit([&](handler& cgh) {
       auto accB = pMap.get_access<access::mode::discard_write,
                                   access::target::global_buffer, float>(b, cgh);
-      cgh.parallel_for<class init_b>(range<1>{N * M}, [=](item<1> index) {
+      cgh.parallel_for<init_b>(range<1>{N * M}, [=](item<1> index) {
         accB[index] = index[0] * 2014;
       });
     });
@@ -82,7 +86,7 @@ int main() {
                                   access::target::global_buffer, float>(b, cgh);
       auto accC = pMap.get_access<access::mode::discard_write,
                                   access::target::global_buffer, float>(c, cgh);
-      cgh.parallel_for<class matrix_add>(range<1>{N * M}, [=](item<1> index) {
+      cgh.parallel_for<matrix_add>(range<1>{N * M}, [=](item<1> index) {
         accC[index] = accA[index] + accB[index];
       });
     });


### PR DESCRIPTION
Some kernel names were not forward declarable, which is illegal in SYCL 1.2.1.
Add a forward declaration to those kernel name to make them globally visible.