### PR TITLE
Updated hello world sample to comply with the requirement that queues n SYCL 1.2.1 are not waited upon their destruction

### DIFF
--- a/samples/hello-world/hello-world.cpp
+++ b/samples/hello-world/hello-world.cpp
@@ -72,6 +72,6 @@ int main() {
       os << "Hello, World!\n";
     });
   });
-
+  myQueue.wait_and_throw();
   return 0;
 }


### PR DESCRIPTION
SYCL 1.2.1 does not require a queue to be waited upon its destruction leading to threads not have completed before the main thread finishes.