### PR TITLE
Adding a README to /samples

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,3 +1,5 @@
+## ComputeCpp SDK - Code Samples
+
 | Sample File | Sample Description |
 | ------------- | ------------- |
 | `accessors.cpp`  | Sample code that illustrates how to make data **available on a device** using **accessors** in SYCL.  |

--- a/samples/README.md
+++ b/samples/README.md
@@ -15,6 +15,7 @@
 | `reduction.cpp`  | Example of a **reduction operation** in SYCL. It is a good demonstration of **memory management** in SYCL. |
 | `matrix-multiply.cpp`  | Example of **tiled matrix multiplication** in SYCL. It compares similarities/differences to an alternative OpenMP implementation.  |
 | `monte-carlo-pi.cpp`  | Example of Monte-Carlo Pi approximation algorithm in SYCL. It also demonstrates how to **query** the **maximum** number of **work-items** in a work-group to check if a kernel can be executed with the initially desired work-group size.  |
+| `simple-private-memory.cpp`  | Sample showing how to utilize private memory on a device using the hierarchical API in SYCL.  |
 | `images.cpp`  |  Sample code that demonstrates a **basic** use of SYCL **image** and **sampler** objects.  |
 | `gaussian-blur.cpp`  | This code implements a **Gaussian Blur filter**, blurring a JPG or PNG image from the command line. The original image file is not modified. Demonstrates a **more advanced** use of SYCL **image** and **sampler** objects. |
 | `reinterpret.cpp`  | Sample code showing the **reinterpret buffer** feature of SYCL 1.2.1. Buffers of **one type** can be **transformed** into buffers of **another type**, similar to C++'s reinterpret_cast feature. |

--- a/samples/README.md
+++ b/samples/README.md
@@ -3,12 +3,12 @@
 ### SYCL Basics
 
 Sample File                     | Description 
-------------------------------- | ---------------------------------------------------------------------------------------------------------
+------------------------------- | -----------------------------------------------------------------------------------------------
 accessors.cpp                   | Making data available on a device using accessors in SYCL.
 parallel-for.cpp                | Using the parallel_for API in SYCL.
 simple-vector-add.cpp           | A "Hello World" example of a simple vector addition in SYCL.
-example-sycl-application.cpp    | Another "Hello World" example that walks through the basics** of executing a matrix add in SYCL.
-simple-example-of-vectors.cpp   | Example of vector operations in SYCL - also demonstrates **swizzles.
+example-sycl-application.cpp    | Another "Hello World" example that walks through the basics of executing a <br> matrix add in SYCL.
+simple-example-of-vectors.cpp   | Example of vector operations in SYCL - also demonstrates swizzles.
 sync-handler.cpp                | Synchronous error handling in SYCL.
 async-handler.cpp               | Asynchronous error handling in SYCL.
 simple-local-barrier.cpp        | Basic use of local barriers in device code.
@@ -19,21 +19,21 @@ matrix-multiply.cpp             | Tiled matrix multiplication - comparing SYCL a
 simple-private-memory.cpp       | Utilizing private memory on a device using the hierarchical API in SYCL.
 images.cpp                      | Basic use of SYCL image and sampler objects.
 custom-device-selector.cpp      | Writing a custom device selector in SYCL.
-ivka.cpp                        | Sample showing the different kinds of things that are valid and not valid when used as kernel arguments.
+ivka.cpp                        | Sample showing the different kinds of things that are valid and not valid when <br> used as kernel arguments.
 
 ---
 
 ### More Advanced SYCL
 
 Sample File                     | Description 
-------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------
-monte-carlo-pi.cpp              | Monte-Carlo Pi approximation algorithm in SYCL. Shows how to query the maximum number of work-items in a work-group to check if a kernel can be executed with the initially desired work-group size.
-scan.cpp                        | Example implementation of a parallel inclusive scan with a given associative binary operation in SYCL.
+------------------------------- | -----------------------------------------------------------------------------------------------
+monte-carlo-pi.cpp              | Monte-Carlo Pi approximation algorithm in SYCL. <br> Shows how to query the maximum number of work-items in a work-group to check if a kernel <br> can be executed with the initially desired work-group size.
+scan.cpp                        | Implementation of a parallel inclusive scan with a given associative binary operation in SYCL.
 gaussian-blur.cpp               | This sample implements a Gaussian Blur filter, blurring a JPG or PNG image from the command line. The original image file is not modified. More advanced use of SYCL image and sampler objects.
-reinterpret.cpp                 | Demonstration of the buffer reinterpret feature of SYCL 1.2.1. Buffers of one type can be transformed into buffers of another type, similar to reinterpret_cast feature in standard C++.
+reinterpret.cpp                 | Demonstration of the buffer reinterpret feature of SYCL 1.2.1. <br> Buffers of one type can be transformed into buffers of another type, similar to reinterpret_cast feature in standard C++.
 placeholder-accessors.cpp       | Example use of SYCL placeholder accessors.
 builtin-kernel-example.cpp      | Using an OpenCL built-in kernel with SYCL via the codeplay extension.
 use-onchip-memory.cpp           | Demonstrating the use_onchip_memory extension to SYCL provided by ComputeCpp.
-smart-pointer.cpp               | Custom Allocators in SYCL. Dependency: *stack_allocator.hpp*
-vptr.cpp                        | Using the Virtual Pointer interface in SYCL on matrix addition kernel. Dependency: */include/vptr/virtual_ptr.hpp*
+smart-pointer.cpp               | Custom Allocators in SYCL. <br> Dependency: *stack_allocator.hpp*
+vptr.cpp                        | Using the Virtual Pointer interface in SYCL on matrix addition kernel. <br> Dependency: */include/vptr/virtual_ptr.hpp*
 opencl-c-interop.cpp            | OpenCL/SYCL interopability example.

--- a/samples/README.md
+++ b/samples/README.md
@@ -4,22 +4,22 @@
 
 Sample File                     | Description 
 ------------------------------- | ---------------------------------------------------------------------------------------------------------
-`accessors.cpp`                 | Making data available on a device using accessors in SYCL.
-`parallel-for.cpp`              | Using the parallel_for API in SYCL.
-`simple-vector-add.cpp`         | A "Hello World" example of a simple vector addition in SYCL.
-`example-sycl-application.cpp`  | Another "Hello World" example that walks through the basics** of executing a matrix add in SYCL.
-`simple-example-of-vectors.cpp` | Example of vector operations in SYCL - also demonstrates **swizzles.
-`sync-handler.cpp`              | Synchronous error handling in SYCL.
-`async-handler.cpp`             | Asynchronous error handling in SYCL.
-`simple-local-barrier.cpp`      | Basic use of local barriers in device code.
-`using-function-objects.cpp`    | Using function objects as kernels in SYCL.
-`template-function-object.cpp`  | Using template function objects as kernels in SYCL.
-`reduction.cpp`                 | Example of a reduction operation in SYCL. A good of memory management in SYCL.
-`matrix-multiply.cpp`           | Tiled matrix multiplication - comparing SYCL and OpenMP implementations.
-`simple-private-memory.cpp`     | Utilizing private memory on a device using the hierarchical API in SYCL.
-`images.cpp`                    | Basic use of SYCL image and sampler objects.
-`custom-device-selector.cpp`    | Writing a custom device selector in SYCL.
-`ivka.cpp`                      | Sample showing the different kinds of things that are valid and not valid when used as kernel arguments.
+accessors.cpp                   | Making data available on a device using accessors in SYCL.
+parallel-for.cpp                | Using the parallel_for API in SYCL.
+simple-vector-add.cpp           | A "Hello World" example of a simple vector addition in SYCL.
+example-sycl-application.cpp    | Another "Hello World" example that walks through the basics** of executing a matrix add in SYCL.
+simple-example-of-vectors.cpp   | Example of vector operations in SYCL - also demonstrates **swizzles.
+sync-handler.cpp                | Synchronous error handling in SYCL.
+async-handler.cpp               | Asynchronous error handling in SYCL.
+simple-local-barrier.cpp        | Basic use of local barriers in device code.
+using-function-objects.cpp      | Using function objects as kernels in SYCL.
+template-function-object.cpp    | Using template function objects as kernels in SYCL.
+reduction.cpp                   | Example of a reduction operation in SYCL. A good of memory management in SYCL.
+matrix-multiply.cpp             | Tiled matrix multiplication - comparing SYCL and OpenMP implementations.
+simple-private-memory.cpp       | Utilizing private memory on a device using the hierarchical API in SYCL.
+images.cpp                      | Basic use of SYCL image and sampler objects.
+custom-device-selector.cpp      | Writing a custom device selector in SYCL.
+ivka.cpp                        | Sample showing the different kinds of things that are valid and not valid when used as kernel arguments.
 
 ---
 
@@ -27,13 +27,13 @@ Sample File                     | Description
 
 Sample File                     | Description 
 ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------
-`monte-carlo-pi.cpp`            | Monte-Carlo Pi approximation algorithm in SYCL. Shows how to query the maximum number of work-items in a work-group to check if a kernel can be executed with the initially desired work-group size.
-`scan.cpp`                      | Example implementation of a parallel inclusive scan with a given associative binary operation in SYCL.
-`gaussian-blur.cpp`             | This sample implements a Gaussian Blur filter, blurring a JPG or PNG image from the command line. The original image file is not modified. More advanced use of SYCL image and sampler objects.
-`reinterpret.cpp`               | Demonstration of the buffer reinterpret feature of SYCL 1.2.1. Buffers of one type can be transformed into buffers of another type, similar to reinterpret_cast feature in standard C++.
-`placeholder-accessors.cpp`     | Example use of SYCL placeholder accessors.
-`builtin-kernel-example.cpp`    | Using an OpenCL built-in kernel with SYCL via the codeplay extension.
-`use-onchip-memory.cpp`         | Demonstrating the use_onchip_memory extension to SYCL provided by ComputeCpp.
-`smart-pointer.cpp`             | Custom Allocators in SYCL. Dependency: `stack_allocator.hpp`
-`vptr.cpp`                      | Using the Virtual Pointer interface in SYCL on matrix addition kernel. Dependency: `/include/vptr/virtual_ptr.hpp`
-`opencl-c-interop.cpp`          | OpenCL/SYCL interopability example.
+monte-carlo-pi.cpp              | Monte-Carlo Pi approximation algorithm in SYCL. Shows how to query the maximum number of work-items in a work-group to check if a kernel can be executed with the initially desired work-group size.
+scan.cpp                        | Example implementation of a parallel inclusive scan with a given associative binary operation in SYCL.
+gaussian-blur.cpp               | This sample implements a Gaussian Blur filter, blurring a JPG or PNG image from the command line. The original image file is not modified. More advanced use of SYCL image and sampler objects.
+reinterpret.cpp                 | Demonstration of the buffer reinterpret feature of SYCL 1.2.1. Buffers of one type can be transformed into buffers of another type, similar to reinterpret_cast feature in standard C++.
+placeholder-accessors.cpp       | Example use of SYCL placeholder accessors.
+builtin-kernel-example.cpp      | Using an OpenCL built-in kernel with SYCL via the codeplay extension.
+use-onchip-memory.cpp           | Demonstrating the use_onchip_memory extension to SYCL provided by ComputeCpp.
+smart-pointer.cpp               | Custom Allocators in SYCL. Dependency: *stack_allocator.hpp*
+vptr.cpp                        | Using the Virtual Pointer interface in SYCL on matrix addition kernel. Dependency: */include/vptr/virtual_ptr.hpp*
+opencl-c-interop.cpp            | OpenCL/SYCL interopability example.

--- a/samples/README.md
+++ b/samples/README.md
@@ -14,7 +14,7 @@ Sample File                       | Description
 `simple-local-barrier.cpp`        | Basic use of local barriers in device code.
 `using-function-objects.cpp`      | Using function objects as kernels in SYCL.
 `template-function-object.cpp`    | Using template function objects as kernels in SYCL.
-`reduction.cpp`                   | Example of a reduction operation in SYCL. A good of memory management in SYCL.
+`reduction.cpp`                   | Exemplifies good memory management in SYCL by implementing a reduction operation.
 `matrix-multiply.cpp`             | Tiled matrix multiplication - comparing SYCL and OpenMP implementations.
 `simple-private-memory.cpp`       | Utilizing private memory on a device using the hierarchical API in SYCL.
 `images.cpp`                      | Basic use of SYCL image and sampler objects.
@@ -34,6 +34,6 @@ Sample File                       | Description
 `placeholder-accessors.cpp`       | Example use of SYCL placeholder accessors.
 `builtin-kernel-example.cpp`      | Using an OpenCL built-in kernel with SYCL via the codeplay extension.
 `use-onchip-memory.cpp`           | Demonstrating the use_onchip_memory extension to SYCL provided by ComputeCpp.
-`smart-pointer.cpp`               | Custom Allocators in SYCL. Dependency: `stack_allocator.hpp`
-`vptr.cpp`                        | Using the Virtual Pointer interface in SYCL on matrix addition kernel. Dependency: `/include/vptr/virtual_ptr.hpp`
+`smart-pointer.cpp`               | Custom Allocators in SYCL.
+`vptr.cpp`                        | Using the Virtual Pointer interface in SYCL on matrix addition kernel.
 `opencl-c-interop.cpp`            | OpenCL/SYCL interopability example.

--- a/samples/README.md
+++ b/samples/README.md
@@ -12,6 +12,8 @@
 | `simple-local-barrier.cpp`  | Sample code demonstrating a basic use of **local barriers** in device code.  |
 | `custom-device-selector.cpp`  | Sample code that shows how to write a **custom device selector** in SYCL.  |
 | `ivka.cpp`  | Sample showing the different kinds of things that are **valid** and **not valid** when used as **kernel arguments**.  |
+| `using-function-objects.cpp`  | Sample code that demonstrates how to use **function objects as kernels** in SYCL.  |
+| `template-function-object.cpp`  |  Sample code that demonstrates how to **template function objects as kernels** in SYCL.  |
 | `reduction.cpp`  | Example of a **reduction operation** in SYCL. It is a good demonstration of **memory management** in SYCL. |
 | `matrix-multiply.cpp`  | Example of **tiled matrix multiplication** in SYCL. It compares similarities/differences to an alternative OpenMP implementation.  |
 | `monte-carlo-pi.cpp`  | Example of Monte-Carlo Pi approximation algorithm in SYCL. It also demonstrates how to **query** the **maximum** number of **work-items** in a work-group to check if a kernel can be executed with the initially desired work-group size.  |
@@ -21,8 +23,6 @@
 | `reinterpret.cpp`  | Sample code showing the **reinterpret buffer** feature of SYCL 1.2.1. Buffers of **one type** can be **transformed** into buffers of **another type**, similar to C++'s reinterpret_cast feature. |
 | `scan.cpp`  | Example of a **parallel inclusive scan** with a given associative **binary operation** in SYCL.  |
 | `placeholder-accessors.cpp`  | Sample code that illustrates how to use placeholder accessors.  |
-| `using-function-objects.cpp`  | Sample code that demonstrates how to use **function objects as kernels** in SYCL.  |
-| `template-function-object.cpp`  |  Sample code that demonstrates how to **template function objects as kernels** in SYCL.  |
 | `builtin-kernel-example.cpp`  | Example of using an **OpenCL built-in kernel** with SYCL via the codeplay extension.  |
 | `use-onchip-memory.cpp`  | Sample code that demonstrates the use of the **use_onchip_memory extension** to SYCL provided by ComputeCpp.  |
 | `smart-pointer.cpp`  | Sample code that shows how SYCL can use custom allocators. <br> Dependency: `stack_allocator.hpp` |

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,27 @@
+| Sample File | Sample Description |
+| ------------- | ------------- |
+| `accessors.cpp`  | Sample code that illustrates how to make data **available on a device** using **accessors** in SYCL.  |
+| `parallel-for.cpp`  | Sample code showing how to use the **parallel_for** API in SYCL.  |
+| `simple-vector-add.cpp`  | A "Hello World" example of a **simple vector addition** in SYCL.  |
+| `example-sycl-application.cpp`  | Another "Hello World" sample code that **walks through the basics** of executing a matrix add in SYCL.  |
+| `simple-example-of-vectors.cpp`  | Example of **vector** operations in SYCL - also demonstrates **swizzles**.  |
+| `sync-handler.cpp`  | Sample code that demonstrates the use of a **synchronous error handler** to demonstrate error handling.  |
+| `async-handler.cpp`  | Sample code that demonstrates the use of an **asynchronous handler** for exceptions in SYCL.  |
+| `simple-local-barrier.cpp`  | Sample code demonstrating a basic use of **local barriers** in device code.  |
+| `custom-device-selector.cpp`  | Sample code that shows how to write a **custom device selector** in SYCL.  |
+| `ivka.cpp`  | Sample showing the different kinds of things that are **valid** and **not valid** when used as **kernel arguments**.  |
+| `reduction.cpp`  | Example of a **reduction operation** in SYCL. It is a good demonstration of **memory management** in SYCL. |
+| `matrix-multiply.cpp`  | Example of **tiled matrix multiplication** in SYCL. It compares similarities/differences to an alternative OpenMP implementation.  |
+| `monte-carlo-pi.cpp`  | Example of Monte-Carlo Pi approximation algorithm in SYCL. It also demonstrates how to **query** the **maximum** number of **work-items** in a work-group to check if a kernel can be executed with the initially desired work-group size.  |
+| `images.cpp`  |  Sample code that demonstrates a **basic** use of SYCL **image** and **sampler** objects.  |
+| `gaussian-blur.cpp`  | This code implements a **Gaussian Blur filter**, blurring a JPG or PNG image from the command line. The original image file is not modified. Demonstrates a **more advanced** use of SYCL **image** and **sampler** objects. |
+| `reinterpret.cpp`  | Sample code showing the **reinterpret buffer** feature of SYCL 1.2.1. Buffers of **one type** can be **transformed** into buffers of **another type**, similar to C++'s reinterpret_cast feature. |
+| `scan.cpp`  | Example of a **parallel inclusive scan** with a given associative **binary operation** in SYCL.  |
+| `placeholder-accessors.cpp`  | Sample code that illustrates how to use placeholder accessors.  |
+| `using-function-objects.cpp`  | Sample code that demonstrates how to use **function objects as kernels** in SYCL.  |
+| `template-function-object.cpp`  |  Sample code that demonstrates how to **template function objects as kernels** in SYCL.  |
+| `builtin-kernel-example.cpp`  | Example of using an **OpenCL built-in kernel** with SYCL via the codeplay extension.  |
+| `use-onchip-memory.cpp`  | Sample code that demonstrates the use of the **use_onchip_memory extension** to SYCL provided by ComputeCpp.  |
+| `smart-pointer.cpp`  | Sample code that shows how SYCL can use custom allocators. <br> Dependency: `stack_allocator.hpp` |
+| `vptr.cpp`  | Sample code that demonstrates the use of the **virtual pointer interface** in SYCL on matrix addition. <br> Dependency: `/include/vptr/virtual_ptr.hpp` |
+| `opencl-c-interop.cpp`  | Sample code that shows the **interoperability** between **OpenCL and SYCL**.  |

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,5 +1,7 @@
 ## ComputeCpp SDK - Code Samples
 
+### SYCL Basics
+
 | Sample File | Sample Description |
 | ------------- | ------------- |
 | `accessors.cpp`  | Sample code that illustrates how to make data **available on a device** using **accessors** in SYCL.  |
@@ -10,18 +12,24 @@
 | `sync-handler.cpp`  | Sample code that demonstrates the use of a **synchronous error handler** to demonstrate error handling.  |
 | `async-handler.cpp`  | Sample code that demonstrates the use of an **asynchronous handler** for exceptions in SYCL.  |
 | `simple-local-barrier.cpp`  | Sample code demonstrating a basic use of **local barriers** in device code.  |
-| `custom-device-selector.cpp`  | Sample code that shows how to write a **custom device selector** in SYCL.  |
-| `ivka.cpp`  | Sample showing the different kinds of things that are **valid** and **not valid** when used as **kernel arguments**.  |
 | `using-function-objects.cpp`  | Sample code that demonstrates how to use **function objects as kernels** in SYCL.  |
 | `template-function-object.cpp`  |  Sample code that demonstrates how to **template function objects as kernels** in SYCL.  |
 | `reduction.cpp`  | Example of a **reduction operation** in SYCL. It is a good demonstration of **memory management** in SYCL. |
 | `matrix-multiply.cpp`  | Example of **tiled matrix multiplication** in SYCL. It compares similarities/differences to an alternative OpenMP implementation.  |
-| `monte-carlo-pi.cpp`  | Example of Monte-Carlo Pi approximation algorithm in SYCL. It also demonstrates how to **query** the **maximum** number of **work-items** in a work-group to check if a kernel can be executed with the initially desired work-group size.  |
 | `simple-private-memory.cpp`  | Sample showing how to utilize **private memory** on a device using the **hierarchical API** in SYCL.  |
 | `images.cpp`  |  Sample code that demonstrates a **basic** use of SYCL **image** and **sampler** objects.  |
+| `custom-device-selector.cpp`  | Sample code that shows how to write a **custom device selector** in SYCL.  |
+| `ivka.cpp`  | Sample showing the different kinds of things that are **valid** and **not valid** when used as **kernel arguments**.  |
+
+---
+
+### More Advanced SYCL
+| Sample File | Sample Description |
+| ------------- | ------------- |
+| `monte-carlo-pi.cpp`  | Example of Monte-Carlo Pi approximation algorithm in SYCL. It also demonstrates how to **query** the **maximum** number of **work-items** in a work-group to check if a kernel can be executed with the initially desired work-group size.  |
+| `scan.cpp`  | Example of a **parallel inclusive scan** with a given associative **binary operation** in SYCL.  |
 | `gaussian-blur.cpp`  | This code implements a **Gaussian Blur filter**, blurring a JPG or PNG image from the command line. The original image file is not modified. Demonstrates a **more advanced** use of SYCL **image** and **sampler** objects. |
 | `reinterpret.cpp`  | Sample code showing the **reinterpret buffer** feature of SYCL 1.2.1. Buffers of **one type** can be **transformed** into buffers of **another type**, similar to C++'s reinterpret_cast feature. |
-| `scan.cpp`  | Example of a **parallel inclusive scan** with a given associative **binary operation** in SYCL.  |
 | `placeholder-accessors.cpp`  | Sample code that illustrates how to use placeholder accessors.  |
 | `builtin-kernel-example.cpp`  | Example of using an **OpenCL built-in kernel** with SYCL via the codeplay extension.  |
 | `use-onchip-memory.cpp`  | Sample code that demonstrates the use of the **use_onchip_memory extension** to SYCL provided by ComputeCpp.  |

--- a/samples/README.md
+++ b/samples/README.md
@@ -2,38 +2,38 @@
 
 ### SYCL Basics
 
-Sample File                     | Description 
-------------------------------- | -----------------------------------------------------------------------------------------------
-accessors.cpp                   | Making data available on a device using accessors in SYCL.
-parallel-for.cpp                | Using the parallel_for API in SYCL.
-simple-vector-add.cpp           | A "Hello World" example of a simple vector addition in SYCL.
-example-sycl-application.cpp    | Another "Hello World" example that walks through the basics of executing a <br> matrix add in SYCL.
-simple-example-of-vectors.cpp   | Example of vector operations in SYCL - also demonstrates swizzles.
-sync-handler.cpp                | Synchronous error handling in SYCL.
-async-handler.cpp               | Asynchronous error handling in SYCL.
-simple-local-barrier.cpp        | Basic use of local barriers in device code.
-using-function-objects.cpp      | Using function objects as kernels in SYCL.
-template-function-object.cpp    | Using template function objects as kernels in SYCL.
-reduction.cpp                   | Example of a reduction operation in SYCL. A good of memory management in SYCL.
-matrix-multiply.cpp             | Tiled matrix multiplication - comparing SYCL and OpenMP implementations.
-simple-private-memory.cpp       | Utilizing private memory on a device using the hierarchical API in SYCL.
-images.cpp                      | Basic use of SYCL image and sampler objects.
-custom-device-selector.cpp      | Writing a custom device selector in SYCL.
-ivka.cpp                        | Sample showing the different kinds of things that are valid and not valid when <br> used as kernel arguments.
+Sample File                       | Description 
+--------------------------------- | --------------------------------------------------------------------------------------------------------
+`accessors.cpp`                   | Making data available on a device using accessors in SYCL.
+`parallel-for.cpp`                | Using the parallel_for API in SYCL.
+`simple-vector-add.cpp`           | A "Hello World" example of a simple vector addition in SYCL.
+`example-sycl-application.cpp`    | Another "Hello World" example that walks through the basics of executing a matrix add in SYCL.
+`simple-example-of-vectors.cpp`   | Example of vector operations in SYCL - also demonstrates swizzles.
+`sync-handler.cpp`                | Synchronous error handling in SYCL.
+`async-handler.cpp`               | Asynchronous error handling in SYCL.
+`simple-local-barrier.cpp`        | Basic use of local barriers in device code.
+`using-function-objects.cpp`      | Using function objects as kernels in SYCL.
+`template-function-object.cpp`    | Using template function objects as kernels in SYCL.
+`reduction.cpp`                   | Example of a reduction operation in SYCL. A good of memory management in SYCL.
+`matrix-multiply.cpp`             | Tiled matrix multiplication - comparing SYCL and OpenMP implementations.
+`simple-private-memory.cpp`       | Utilizing private memory on a device using the hierarchical API in SYCL.
+`images.cpp`                      | Basic use of SYCL image and sampler objects.
+`custom-device-selector.cpp`      | Writing a custom device selector in SYCL.
+`ivka.cpp`                        | Sample showing the different kinds of things that are valid and not valid when used as kernel arguments.
 
 ---
 
 ### More Advanced SYCL
 
-Sample File                     | Description 
-------------------------------- | -----------------------------------------------------------------------------------------------
-monte-carlo-pi.cpp              | Monte-Carlo Pi approximation algorithm in SYCL. <br> Shows how to query the maximum number of work-items in a work-group to check if a kernel <br> can be executed with the initially desired work-group size.
-scan.cpp                        | Implementation of a parallel inclusive scan with a given associative binary operation in SYCL.
-gaussian-blur.cpp               | This sample implements a Gaussian Blur filter, blurring a JPG or PNG image from the command line. The original image file is not modified. More advanced use of SYCL image and sampler objects.
-reinterpret.cpp                 | Demonstration of the buffer reinterpret feature of SYCL 1.2.1. <br> Buffers of one type can be transformed into buffers of another type, similar to reinterpret_cast feature in standard C++.
-placeholder-accessors.cpp       | Example use of SYCL placeholder accessors.
-builtin-kernel-example.cpp      | Using an OpenCL built-in kernel with SYCL via the codeplay extension.
-use-onchip-memory.cpp           | Demonstrating the use_onchip_memory extension to SYCL provided by ComputeCpp.
-smart-pointer.cpp               | Custom Allocators in SYCL. <br> Dependency: *stack_allocator.hpp*
-vptr.cpp                        | Using the Virtual Pointer interface in SYCL on matrix addition kernel. <br> Dependency: */include/vptr/virtual_ptr.hpp*
-opencl-c-interop.cpp            | OpenCL/SYCL interopability example.
+Sample File                       | Description 
+--------------------------------  | ---------------------------------------------------------------------------------------------------------------------------------
+`monte-carlo-pi.cpp`              | Monte-Carlo Pi approximation algorithm in SYCL. Shows how to query the maximum number of work-items in a work-group to check if a kernel can be executed with the initially desired work-group size.
+`scan.cpp`                        | Implementation of a parallel inclusive scan with a given associative binary operation in SYCL.
+`gaussian-blur.cpp`               | This sample implements a Gaussian Blur filter, blurring a JPG or PNG image from the command line. The original image file is not modified. More advanced use of SYCL image and sampler objects.
+`reinterpret.cpp`                 | Demonstration of the buffer reinterpret feature of SYCL 1.2.1. Buffers of one type can be transformed into buffers of another type, similar to reinterpret_cast feature in standard C++.
+`placeholder-accessors.cpp`       | Example use of SYCL placeholder accessors.
+`builtin-kernel-example.cpp`      | Using an OpenCL built-in kernel with SYCL via the codeplay extension.
+`use-onchip-memory.cpp`           | Demonstrating the use_onchip_memory extension to SYCL provided by ComputeCpp.
+`smart-pointer.cpp`               | Custom Allocators in SYCL. Dependency: `stack_allocator.hpp`
+`vptr.cpp`                        | Using the Virtual Pointer interface in SYCL on matrix addition kernel. Dependency: `/include/vptr/virtual_ptr.hpp`
+`opencl-c-interop.cpp`            | OpenCL/SYCL interopability example.

--- a/samples/README.md
+++ b/samples/README.md
@@ -15,7 +15,7 @@
 | `reduction.cpp`  | Example of a **reduction operation** in SYCL. It is a good demonstration of **memory management** in SYCL. |
 | `matrix-multiply.cpp`  | Example of **tiled matrix multiplication** in SYCL. It compares similarities/differences to an alternative OpenMP implementation.  |
 | `monte-carlo-pi.cpp`  | Example of Monte-Carlo Pi approximation algorithm in SYCL. It also demonstrates how to **query** the **maximum** number of **work-items** in a work-group to check if a kernel can be executed with the initially desired work-group size.  |
-| `simple-private-memory.cpp`  | Sample showing how to utilize private memory on a device using the hierarchical API in SYCL.  |
+| `simple-private-memory.cpp`  | Sample showing how to utilize **private memory** on a device using the **hierarchical API** in SYCL.  |
 | `images.cpp`  |  Sample code that demonstrates a **basic** use of SYCL **image** and **sampler** objects.  |
 | `gaussian-blur.cpp`  | This code implements a **Gaussian Blur filter**, blurring a JPG or PNG image from the command line. The original image file is not modified. Demonstrates a **more advanced** use of SYCL **image** and **sampler** objects. |
 | `reinterpret.cpp`  | Sample code showing the **reinterpret buffer** feature of SYCL 1.2.1. Buffers of **one type** can be **transformed** into buffers of **another type**, similar to C++'s reinterpret_cast feature. |

--- a/samples/README.md
+++ b/samples/README.md
@@ -2,37 +2,38 @@
 
 ### SYCL Basics
 
-| Sample File | Sample Description |
-| ------------- | ------------- |
-| `accessors.cpp`  | Sample code that illustrates how to make data **available on a device** using **accessors** in SYCL.  |
-| `parallel-for.cpp`  | Sample code showing how to use the **parallel_for** API in SYCL.  |
-| `simple-vector-add.cpp`  | A "Hello World" example of a **simple vector addition** in SYCL.  |
-| `example-sycl-application.cpp`  | Another "Hello World" sample code that **walks through the basics** of executing a matrix add in SYCL.  |
-| `simple-example-of-vectors.cpp`  | Example of **vector** operations in SYCL - also demonstrates **swizzles**.  |
-| `sync-handler.cpp`  | Sample code that demonstrates the use of a **synchronous error handler** to demonstrate error handling.  |
-| `async-handler.cpp`  | Sample code that demonstrates the use of an **asynchronous handler** for exceptions in SYCL.  |
-| `simple-local-barrier.cpp`  | Sample code demonstrating a basic use of **local barriers** in device code.  |
-| `using-function-objects.cpp`  | Sample code that demonstrates how to use **function objects as kernels** in SYCL.  |
-| `template-function-object.cpp`  |  Sample code that demonstrates how to **template function objects as kernels** in SYCL.  |
-| `reduction.cpp`  | Example of a **reduction operation** in SYCL. It is a good demonstration of **memory management** in SYCL. |
-| `matrix-multiply.cpp`  | Example of **tiled matrix multiplication** in SYCL. It compares similarities/differences to an alternative OpenMP implementation.  |
-| `simple-private-memory.cpp`  | Sample showing how to utilize **private memory** on a device using the **hierarchical API** in SYCL.  |
-| `images.cpp`  |  Sample code that demonstrates a **basic** use of SYCL **image** and **sampler** objects.  |
-| `custom-device-selector.cpp`  | Sample code that shows how to write a **custom device selector** in SYCL.  |
-| `ivka.cpp`  | Sample showing the different kinds of things that are **valid** and **not valid** when used as **kernel arguments**.  |
+Sample File                     | Description 
+------------------------------- | ---------------------------------------------------------------------------------------------------------
+`accessors.cpp`                 | Making data available on a device using accessors in SYCL.
+`parallel-for.cpp`              | Using the parallel_for API in SYCL.
+`simple-vector-add.cpp`         | A "Hello World" example of a simple vector addition in SYCL.
+`example-sycl-application.cpp`  | Another "Hello World" example that walks through the basics** of executing a matrix add in SYCL.
+`simple-example-of-vectors.cpp` | Example of vector operations in SYCL - also demonstrates **swizzles.
+`sync-handler.cpp`              | Synchronous error handling in SYCL.
+`async-handler.cpp`             | Asynchronous error handling in SYCL.
+`simple-local-barrier.cpp`      | Basic use of local barriers in device code.
+`using-function-objects.cpp`    | Using function objects as kernels in SYCL.
+`template-function-object.cpp`  | Using template function objects as kernels in SYCL.
+`reduction.cpp`                 | Example of a reduction operation in SYCL. A good of memory management in SYCL.
+`matrix-multiply.cpp`           | Tiled matrix multiplication - comparing SYCL and OpenMP implementations.
+`simple-private-memory.cpp`     | Utilizing private memory on a device using the hierarchical API in SYCL.
+`images.cpp`                    | Basic use of SYCL image and sampler objects.
+`custom-device-selector.cpp`    | Writing a custom device selector in SYCL.
+`ivka.cpp`                      | Sample showing the different kinds of things that are valid and not valid when used as kernel arguments.
 
 ---
 
 ### More Advanced SYCL
-| Sample File | Sample Description |
-| ------------- | ------------- |
-| `monte-carlo-pi.cpp`  | Example of Monte-Carlo Pi approximation algorithm in SYCL. It also demonstrates how to **query** the **maximum** number of **work-items** in a work-group to check if a kernel can be executed with the initially desired work-group size.  |
-| `scan.cpp`  | Example of a **parallel inclusive scan** with a given associative **binary operation** in SYCL.  |
-| `gaussian-blur.cpp`  | This code implements a **Gaussian Blur filter**, blurring a JPG or PNG image from the command line. The original image file is not modified. Demonstrates a **more advanced** use of SYCL **image** and **sampler** objects. |
-| `reinterpret.cpp`  | Sample code showing the **reinterpret buffer** feature of SYCL 1.2.1. Buffers of **one type** can be **transformed** into buffers of **another type**, similar to C++'s reinterpret_cast feature. |
-| `placeholder-accessors.cpp`  | Sample code that illustrates how to use placeholder accessors.  |
-| `builtin-kernel-example.cpp`  | Example of using an **OpenCL built-in kernel** with SYCL via the codeplay extension.  |
-| `use-onchip-memory.cpp`  | Sample code that demonstrates the use of the **use_onchip_memory extension** to SYCL provided by ComputeCpp.  |
-| `smart-pointer.cpp`  | Sample code that shows how SYCL can use custom allocators. <br> Dependency: `stack_allocator.hpp` |
-| `vptr.cpp`  | Sample code that demonstrates the use of the **virtual pointer interface** in SYCL on matrix addition. <br> Dependency: `/include/vptr/virtual_ptr.hpp` |
-| `opencl-c-interop.cpp`  | Sample code that shows the **interoperability** between **OpenCL and SYCL**.  |
+
+Sample File                     | Description 
+------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------
+`monte-carlo-pi.cpp`            | Monte-Carlo Pi approximation algorithm in SYCL. Shows how to query the maximum number of work-items in a work-group to check if a kernel can be executed with the initially desired work-group size.
+`scan.cpp`                      | Example implementation of a parallel inclusive scan with a given associative binary operation in SYCL.
+`gaussian-blur.cpp`             | This sample implements a Gaussian Blur filter, blurring a JPG or PNG image from the command line. The original image file is not modified. More advanced use of SYCL image and sampler objects.
+`reinterpret.cpp`               | Demonstration of the buffer reinterpret feature of SYCL 1.2.1. Buffers of one type can be transformed into buffers of another type, similar to reinterpret_cast feature in standard C++.
+`placeholder-accessors.cpp`     | Example use of SYCL placeholder accessors.
+`builtin-kernel-example.cpp`    | Using an OpenCL built-in kernel with SYCL via the codeplay extension.
+`use-onchip-memory.cpp`         | Demonstrating the use_onchip_memory extension to SYCL provided by ComputeCpp.
+`smart-pointer.cpp`             | Custom Allocators in SYCL. Dependency: `stack_allocator.hpp`
+`vptr.cpp`                      | Using the Virtual Pointer interface in SYCL on matrix addition kernel. Dependency: `/include/vptr/virtual_ptr.hpp`
+`opencl-c-interop.cpp`          | OpenCL/SYCL interopability example.

--- a/samples/monte-carlo-pi.cpp
+++ b/samples/monte-carlo-pi.cpp
@@ -21,7 +21,7 @@
  *  monte-carlo-pi.cpp
  *
  *  Description:
- *    Example of Monte-Carlo Pi approxamtion algorithm in SYCL. Also,
+ *    Example of Monte-Carlo Pi approximation algorithm in SYCL. Also,
  *    demonstrating how to query the maximum number of work-items in a
  *    work-group to check if a kernel can be executed with the initially
  *    desired work-group size.

--- a/samples/vptr.cpp
+++ b/samples/vptr.cpp
@@ -21,8 +21,8 @@
  *  example_vptr.cpp
  *
  *  Description:
- *  Sample code that demonstrates the use of the virtual pointer intrface in
- *SYCL on matrix addition.
+ *  Sample code that demonstrates the use of the virtual pointer interface in
+ *  SYCL on matrix addition.
  *
  **************************************************************************/
 


### PR DESCRIPTION
Includes a description of what all the samples do, separating SYCL basics from more "advanced" usage.