### PR TITLE
Fix handling of $PATH in FindComputeCpp.cmake

### DIFF
--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -65,11 +65,13 @@ endif()
 
 find_program(ComputeCpp_DEVICE_COMPILER_EXECUTABLE compute++
   HINTS ${computecpp_host_find_hint}
-  PATH_SUFFIXES bin)
+  PATH_SUFFIXES bin
+  NO_SYSTEM_ENVIRONMENT_PATH)
 
 find_program(ComputeCpp_INFO_EXECUTABLE computecpp_info
   HINTS ${computecpp_host_find_hint}
-  PATH_SUFFIXES bin)
+  PATH_SUFFIXES bin
+  NO_SYSTEM_ENVIRONMENT_PATH)
 
 find_library(COMPUTECPP_RUNTIME_LIBRARY
   NAMES ComputeCpp ComputeCpp_vs2015


### PR DESCRIPTION
It is unlikely that users will want to find compute++ on the path
with ComputeCpp libraries elsewhere in the system. By passing a
parameter to find_program in CMake, we stop it searching the PATH
and it will always instead find the ComputeCpp components in
system paths or the user-provided hint.