### PR TITLE
Fix the scan example to avoid undefined behavior.

### DIFF
--- a/samples/scan.cpp
+++ b/samples/scan.cpp
@@ -257,7 +257,7 @@ int test_sum(sycl::queue& q) {
   std::vector<int32_t> sum(in.size());
   {
     // Read from `in`, but write into `sum`.
-    sycl::buffer<int32_t, 1> buf(in.data(), sycl::range<1>(in.size()));
+    sycl::buffer<int32_t, 1> buf((const int32_t*)in.data(), sycl::range<1>(in.size()));
     buf.set_final_data(sum.data());
 
     par_scan<int32_t, std::plus<int32_t>>(buf, q);
@@ -299,7 +299,7 @@ int test_factorial(sycl::queue& q) {
   std::vector<int64_t> fact(in.size());
   {
     // Read from `in`, but write into `fact`.
-    sycl::buffer<int64_t, 1> buf(in.data(), sycl::range<1>(in.size()));
+    sycl::buffer<int64_t, 1> buf((const int64_t*)in.data(), sycl::range<1>(in.size()));
     buf.set_final_data(fact.data());
 
     par_scan<int64_t, std::multiplies<int64_t>>(buf, q);


### PR DESCRIPTION
To prevent the original input data from being overwritten, the buffer
constructor with the const pointer input needs to be used. When the
non-const pointer variant is used, the implementation is free to
overwrite the original buffer pointer (if, for example, it chose to use
the CL_MEM_HOST_PTR flag on the underlying OpenCL call), even if it is
being written back to a different data pointer.