### PR TITLE
Remove sudo key from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: cpp
-sudo: required
 dist: xenial
 
 os:


### PR DESCRIPTION
It has been deprecated, and now does nothing.