### PR TITLE
Add missing header file <map> to virtual pointer sample

### DIFF
--- a/include/vptr/virtual_ptr.hpp
+++ b/include/vptr/virtual_ptr.hpp
@@ -39,7 +39,6 @@
 #include <queue>
 #include <set>
 #include <stdexcept>
-#include <unordered_map>
 #include <map>
 
 namespace cl {

--- a/include/vptr/virtual_ptr.hpp
+++ b/include/vptr/virtual_ptr.hpp
@@ -40,6 +40,7 @@
 #include <set>
 #include <stdexcept>
 #include <unordered_map>
+#include <map>
 
 namespace cl {
 namespace sycl {


### PR DESCRIPTION
The vptr.hpp file used in the virtual pointer sample was using std::map but was missing <map> the header file <map>
I have added the <map> header to vptr.hpp to fix the compilation errors.
