### PR TITLE
Update SDK to ComputeCpp v2.0.0

### DIFF
--- a/.travis/build_computecpp.sh
+++ b/.travis/build_computecpp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 set -ev
-wget --no-check-certificate https://computecpp.codeplay.com/downloads/computecpp-ce/1.3.0/ubuntu-16.04-64bit.tar.gz
+wget --no-check-certificate https://computecpp.codeplay.com/downloads/computecpp-ce/2.0.0/x86_64-linux-gnu.tar.gz
 mkdir -p /tmp/computecpp
-tar -xzf ubuntu-16.04-64bit.tar.gz -C /tmp/computecpp --strip-components=1
+tar -xzf x86_64-linux-gnu.tar.gz -C /tmp/computecpp --strip-components=1

--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -74,13 +74,13 @@ find_program(ComputeCpp_INFO_EXECUTABLE computecpp_info
   NO_SYSTEM_ENVIRONMENT_PATH)
 
 find_library(COMPUTECPP_RUNTIME_LIBRARY
-  NAMES ComputeCpp ComputeCpp_vs2015
+  NAMES ComputeCpp
   HINTS ${computecpp_find_hint}
   PATH_SUFFIXES lib
   DOC "ComputeCpp Runtime Library")
 
 find_library(COMPUTECPP_RUNTIME_LIBRARY_DEBUG
-  NAMES ComputeCpp ComputeCpp_vs2015_d
+  NAMES ComputeCpp_d ComputeCpp
   HINTS ${computecpp_find_hint}
   PATH_SUFFIXES lib
   DOC "ComputeCpp Debug Runtime Library")
@@ -153,6 +153,10 @@ endif()
 
 list(APPEND COMPUTECPP_DEVICE_COMPILER_FLAGS -sycl-target ${COMPUTECPP_BITCODE})
 message(STATUS "compute++ flags - ${COMPUTECPP_DEVICE_COMPILER_FLAGS}")
+
+if(MSVC)
+  include(ComputeCppCompilerChecks)
+endif()
 
 if(NOT TARGET OpenCL::OpenCL)
   add_library(OpenCL::OpenCL UNKNOWN IMPORTED)
@@ -398,6 +402,8 @@ function(add_sycl_to_target)
     "${multi_value_args}"
     ${ARGN}
   )
+
+  set_target_properties(${SDK_ADD_SYCL_TARGET} PROPERTIES LINKER_LANGUAGE CXX)
 
   # If the CXX compiler is set to compute++ enable the driver.
   get_filename_component(cmakeCxxCompilerFileName "${CMAKE_CXX_COMPILER}" NAME)

--- a/tests/CMakeLists.txt.in
+++ b/tests/CMakeLists.txt.in
@@ -4,7 +4,7 @@ find_package(Threads)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           release-1.8.0
+  GIT_TAG           release-1.10.0
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
The name of the ComputeCpp library has changed on Windows. Since
we are supporting MSVC 2019 now, we need to include the compiler
checks to make it work, and also need an update to Google Test
to avoid a deprecation in MSVC.