### PR TITLE
Fix missing header in sync-handler sample

### DIFF
--- a/samples/sync-handler.cpp
+++ b/samples/sync-handler.cpp
@@ -28,6 +28,7 @@
 
 #include <CL/sycl.hpp>
 
+#include <algorithm>
 #include <iostream>
 
 using namespace cl::sycl;


### PR DESCRIPTION
`std::any_of` requires `#include <algorithm>`.

Signed-off-by: Alexander Batashev <alexander.batashev@intel.com>