### PR TITLE
Make CMake fail when compute++ can't compile code

### DIFF
--- a/cmake/Modules/ComputeCppCompilerChecks.cmake
+++ b/cmake/Modules/ComputeCppCompilerChecks.cmake
@@ -13,16 +13,17 @@ endif()
 if(MSVC)
   set(ComputeCpp_STL_CHECK_SRC __STL_check)
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${ComputeCpp_STL_CHECK_SRC}.cpp
-    "#include <CL/sycl.hpp>\n"
+    "#include <CL/sycl.hpp>  \n"
     "int main() { return 0; }\n")
+  set(_stl_test_command ${ComputeCpp_DEVICE_COMPILER_EXECUTABLE}
+                        -sycl
+                        ${COMPUTECPP_DEVICE_COMPILER_FLAGS}
+                        -isystem ${ComputeCpp_INCLUDE_DIRS}
+                        -isystem ${OpenCL_INCLUDE_DIRS}
+                        -o ${ComputeCpp_STL_CHECK_SRC}.sycl
+                        -c ${ComputeCpp_STL_CHECK_SRC}.cpp)
   execute_process(
-    COMMAND ${ComputeCpp_DEVICE_COMPILER_EXECUTABLE}
-            -sycl
-            ${COMPUTECPP_DEVICE_COMPILER_FLAGS}
-            -isystem ${ComputeCpp_INCLUDE_DIRS}
-            -isystem ${OpenCL_INCLUDE_DIRS}
-            -o ${ComputeCpp_STL_CHECK_SRC}.sycl
-            -c ${ComputeCpp_STL_CHECK_SRC}.cpp
+    COMMAND ${_stl_test_command}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     RESULT_VARIABLE ComputeCpp_STL_CHECK_RESULT
     ERROR_QUIET
@@ -30,31 +31,19 @@ if(MSVC)
   if(NOT ${ComputeCpp_STL_CHECK_RESULT} EQUAL 0)
     # Try disabling compiler version checks
     execute_process(
-      COMMAND ${ComputeCpp_DEVICE_COMPILER_EXECUTABLE}
-              -sycl
-              ${COMPUTECPP_DEVICE_COMPILER_FLAGS}
+      COMMAND ${_stl_test_command}
               -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
-              -isystem ${ComputeCpp_INCLUDE_DIRS}
-              -isystem ${OpenCL_INCLUDE_DIRS}
-              -o ${ComputeCpp_STL_CHECK_SRC}.cpp.sycl
-              -c ${ComputeCpp_STL_CHECK_SRC}.cpp
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       RESULT_VARIABLE ComputeCpp_STL_CHECK_RESULT
       ERROR_QUIET
       OUTPUT_QUIET)
     if(NOT ${ComputeCpp_STL_CHECK_RESULT} EQUAL 0)
-      # Try again with __CUDACC__ and HAS_CONDITIONAL_EXPLICIT=0. This relaxes the restritions in the MSVC headers
+      # Try again with __CUDACC__ and _HAS_CONDITIONAL_EXPLICIT=0. This relaxes the restritions in the MSVC headers
       execute_process(
-        COMMAND ${ComputeCpp_DEVICE_COMPILER_EXECUTABLE}
-                -sycl
-                ${COMPUTECPP_DEVICE_COMPILER_FLAGS}
+        COMMAND ${_stl_test_command}
                 -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
                 -D_HAS_CONDITIONAL_EXPLICIT=0
                 -D__CUDACC__
-                -isystem ${ComputeCpp_INCLUDE_DIRS}
-                -isystem ${OpenCL_INCLUDE_DIRS}
-                -o ${ComputeCpp_STL_CHECK_SRC}.cpp.sycl
-                -c ${ComputeCpp_STL_CHECK_SRC}.cpp
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         RESULT_VARIABLE ComputeCpp_STL_CHECK_RESULT
         ERROR_QUIET

--- a/cmake/Modules/ComputeCppCompilerChecks.cmake
+++ b/cmake/Modules/ComputeCppCompilerChecks.cmake
@@ -13,12 +13,14 @@ endif()
 if(MSVC)
   set(ComputeCpp_STL_CHECK_SRC __STL_check)
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${ComputeCpp_STL_CHECK_SRC}.cpp
-    "#include <ios>\n"
+    "#include <CL/sycl.hpp>\n"
     "int main() { return 0; }\n")
   execute_process(
     COMMAND ${ComputeCpp_DEVICE_COMPILER_EXECUTABLE}
+            -sycl
             ${COMPUTECPP_DEVICE_COMPILER_FLAGS}
             -isystem ${ComputeCpp_INCLUDE_DIRS}
+            -isystem ${OpenCL_INCLUDE_DIRS}
             -o ${ComputeCpp_STL_CHECK_SRC}.sycl
             -c ${ComputeCpp_STL_CHECK_SRC}.cpp
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
@@ -29,9 +31,11 @@ if(MSVC)
     # Try disabling compiler version checks
     execute_process(
       COMMAND ${ComputeCpp_DEVICE_COMPILER_EXECUTABLE}
+              -sycl
               ${COMPUTECPP_DEVICE_COMPILER_FLAGS}
               -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
               -isystem ${ComputeCpp_INCLUDE_DIRS}
+              -isystem ${OpenCL_INCLUDE_DIRS}
               -o ${ComputeCpp_STL_CHECK_SRC}.cpp.sycl
               -c ${ComputeCpp_STL_CHECK_SRC}.cpp
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
@@ -39,9 +43,31 @@ if(MSVC)
       ERROR_QUIET
       OUTPUT_QUIET)
     if(NOT ${ComputeCpp_STL_CHECK_RESULT} EQUAL 0)
-      message(STATUS "Device compiler cannot consume hosted STL headers. Using any parts of the STL will likely result in device compiler errors.")
+      # Try again with __CUDACC__ and HAS_CONDITIONAL_EXPLICIT=0. This relaxes the restritions in the MSVC headers
+      execute_process(
+        COMMAND ${ComputeCpp_DEVICE_COMPILER_EXECUTABLE}
+                -sycl
+                ${COMPUTECPP_DEVICE_COMPILER_FLAGS}
+                -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
+                -D_HAS_CONDITIONAL_EXPLICIT=0
+                -D__CUDACC__
+                -isystem ${ComputeCpp_INCLUDE_DIRS}
+                -isystem ${OpenCL_INCLUDE_DIRS}
+                -o ${ComputeCpp_STL_CHECK_SRC}.cpp.sycl
+                -c ${ComputeCpp_STL_CHECK_SRC}.cpp
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        RESULT_VARIABLE ComputeCpp_STL_CHECK_RESULT
+        ERROR_QUIET
+        OUTPUT_QUIET)
+        if(NOT ${ComputeCpp_STL_CHECK_RESULT} EQUAL 0)
+          message(FATAL_ERROR "compute++ cannot consume hosted STL headers. This means that compute++ can't \
+                               compile a simple program in this platform and will fail when used in this system.")
+        else()
+          list(APPEND COMPUTECPP_DEVICE_COMPILER_FLAGS -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
+                                                       -D_HAS_CONDITIONAL_EXPLICIT=0
+                                                       -D__CUDACC__)
+        endif()
     else()
-    message(STATUS "Device compiler does not meet certain STL version requirements. Disabling version checks and hoping for the best.")
       list(APPEND COMPUTECPP_DEVICE_COMPILER_FLAGS -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH)
     endif()
   endif()


### PR DESCRIPTION
- compute++ 2.1.0 is based on clang 8 and it can't parse the Windows headers for MSVC 19.27.
- This patch will make CMake try to build a simple program that includes cl/SYCL.hpp
- If the compilation fails we try to compile with __CUDACC__ and HAS_CONDITIONAL_EXPLICIT=0. If compute++ can build the file, those flags are added to COMPUTECPP_DEVICE_COMPILER_FLAGS