### PR TITLE
Support for multiple bitcode targets in COMPUTECPP_BITCODE

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ Lastly, the SDK will build targeting `spir64` IR by default. This will
 work on most devices, but won’t work on NVIDIA (for example). To that
 end, you can specify `-DCOMPUTECPP_BITCODE=target`, which can be any of
 `spir[64]`, `spirv[64]` or `ptx64`.
+It is possible to specify multiple targets to `COMPUTECPP_BITCODE`,
+as a CMake list.
+Note that only the Professional Edition of ComputeCpp
+supports building multiple device targets.
 
 If you would like to crosscompile the SDK targeting some other platform,
 there are toolchain files available in the cmake/toolchains directory.

--- a/cmake/Modules/ComputeCppCompilerChecks.cmake
+++ b/cmake/Modules/ComputeCppCompilerChecks.cmake
@@ -26,7 +26,7 @@ if(MSVC)
     COMMAND ${_stl_test_command}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     RESULT_VARIABLE ComputeCpp_STL_CHECK_RESULT
-    ERROR_QUIET
+    ERROR_VARIABLE ComputeCpp_STL_CHECK_ERROR_OUTPUT
     OUTPUT_QUIET)
   if(NOT ${ComputeCpp_STL_CHECK_RESULT} EQUAL 0)
     # Try disabling compiler version checks
@@ -35,7 +35,7 @@ if(MSVC)
               -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       RESULT_VARIABLE ComputeCpp_STL_CHECK_RESULT
-      ERROR_QUIET
+      ERROR_VARIABLE ComputeCpp_STL_CHECK_ERROR_OUTPUT
       OUTPUT_QUIET)
     if(NOT ${ComputeCpp_STL_CHECK_RESULT} EQUAL 0)
       # Try again with __CUDACC__ and _HAS_CONDITIONAL_EXPLICIT=0. This relaxes the restritions in the MSVC headers
@@ -46,11 +46,12 @@ if(MSVC)
                 -D__CUDACC__
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         RESULT_VARIABLE ComputeCpp_STL_CHECK_RESULT
-        ERROR_QUIET
+        ERROR_VARIABLE ComputeCpp_STL_CHECK_ERROR_OUTPUT
         OUTPUT_QUIET)
         if(NOT ${ComputeCpp_STL_CHECK_RESULT} EQUAL 0)
           message(FATAL_ERROR "compute++ cannot consume hosted STL headers. This means that compute++ can't \
-                               compile a simple program in this platform and will fail when used in this system.")
+                               compile a simple program in this platform and will fail when used in this system. \
+                               \n ${ComputeCpp_STL_CHECK_ERROR_OUTPUT}")
         else()
           list(APPEND COMPUTECPP_DEVICE_COMPILER_FLAGS -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
                                                        -D_HAS_CONDITIONAL_EXPLICIT=0

--- a/cmake/Modules/ComputeCppIRMap.cmake
+++ b/cmake/Modules/ComputeCppIRMap.cmake
@@ -16,3 +16,13 @@ set(IR_MAP_custom-spirv64 spv)
 set(IR_MAP_custom-spirv32 spv)
 set(IR_MAP_ptx64 s)
 set(IR_MAP_amdgcn s)
+
+# Retrieves the filename extension of the IR output of compute++
+function(get_sycl_target_extension output)
+  set(syclExtension ${IR_MAP_${COMPUTECPP_BITCODE}})
+  if(NOT syclExtension)
+    # Needed when using multiple device targets
+    set(syclExtension "bc")
+  endif()
+  set(${output} ${syclExtension} PARENT_SCOPE)
+endfunction()

--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -38,7 +38,7 @@ separate_arguments(COMPUTECPP_USER_FLAGS)
 mark_as_advanced(COMPUTECPP_USER_FLAGS)
 
 set(COMPUTECPP_BITCODE "spir64" CACHE STRING
-  "Bitcode type to use as SYCL target in compute++")
+  "Bitcode types to use as SYCL targets in compute++.")
 mark_as_advanced(COMPUTECPP_BITCODE)
 
 set(SYCL_LANGUAGE_VERSION "2017" CACHE STRING "SYCL version to use. Defaults to 1.2.1.")
@@ -153,8 +153,12 @@ if(CMAKE_CROSSCOMPILING)
   list(APPEND COMPUTECPP_DEVICE_COMPILER_FLAGS -target ${COMPUTECPP_TARGET_TRIPLE})
 endif()
 
-list(APPEND COMPUTECPP_DEVICE_COMPILER_FLAGS -sycl-target ${COMPUTECPP_BITCODE})
 list(APPEND COMPUTECPP_DEVICE_COMPILER_FLAGS -DSYCL_LANGUAGE_VERSION=${SYCL_LANGUAGE_VERSION})
+
+foreach (bitcode IN ITEMS ${COMPUTECPP_BITCODE})
+  list(APPEND COMPUTECPP_DEVICE_COMPILER_FLAGS -sycl-target ${bitcode})
+endforeach()
+
 message(STATUS "compute++ flags - ${COMPUTECPP_DEVICE_COMPILER_FLAGS}")
 
 include(ComputeCppCompilerChecks)
@@ -238,7 +242,8 @@ function(__build_ir)
   # using the same source file will be generated with a different rule.
   set(baseSyclName ${CMAKE_CURRENT_BINARY_DIR}/${SDK_BUILD_IR_TARGET}_${sourceFileName})
   set(outputSyclFile ${baseSyclName}.sycl)
-  set(outputDeviceFile ${baseSyclName}.${IR_MAP_${COMPUTECPP_BITCODE}})
+  get_sycl_target_extension(targetExtension)
+  set(outputDeviceFile ${baseSyclName}.${targetExtension})
   set(depFileName ${baseSyclName}.sycl.d)
 
   set(include_directories "$<TARGET_PROPERTY:${SDK_BUILD_IR_TARGET},INCLUDE_DIRECTORIES>")


### PR DESCRIPTION
Adds support for setting multiple values in `COMPUTECPP_BITCODE`. When using ComputeCpp Professional Edition this allows multiple versions of the same kernel to be available in the same binary.