### PR TITLE
[Build] Option to include integration header last

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,11 @@
 *.ycm_extra_conf.pyc
 .color_coded
 
-# build folder
+# build and IDE folders
 build/
+.vscode
+.vs
+CMakeSettings.json
 
 # Compiled files
 *.o
@@ -28,3 +31,6 @@ build/
 html/
 *.html
 *.pdf
+
+# Generated files
+samples/Lenna-blurred.png

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(ComputeCpp REQUIRED)
 
 option(COMPUTECPP_SDK_USE_OPENMP "Enable OpenMP support in samples" OFF)
 option(COMPUTECPP_SDK_BUILD_TESTS "Build the tests for the header utilities in include/" OFF)
+option(COMPUTECPP_SDK_INCLUDE_AFTER "Force integration header to be included after main" OFF)
 
 set(CMAKE_CXX_STANDARD 14)
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,6 @@ find_package(ComputeCpp REQUIRED)
 
 option(COMPUTECPP_SDK_USE_OPENMP "Enable OpenMP support in samples" OFF)
 option(COMPUTECPP_SDK_BUILD_TESTS "Build the tests for the header utilities in include/" OFF)
-option(COMPUTECPP_SDK_INCLUDE_AFTER "Force integration header to be included after main" OFF)
 
 set(CMAKE_CXX_STANDARD 14)
 enable_testing()

--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -47,22 +47,19 @@ find_package(OpenCL REQUIRED)
 
 # Find ComputeCpp package
 
-if(DEFINED ComputeCpp_DIR)
-  set(computecpp_find_hint ${ComputeCpp_DIR})
-elseif(DEFINED ENV{COMPUTECPP_DIR})
-  set(computecpp_find_hint $ENV{COMPUTECPP_DIR})
-endif()
+set(ComputeCpp_DIR "$ENV{COMPUTECPP_DIR}"
+  CACHE PATH "Path to ComputeCpp root folder")
+# ComputeCpp_HOST_DIR is used to find executables that are run on the host
+set(ComputeCpp_HOST_DIR "$ENV{ComputeCpp_HOST_DIR}"
+  CACHE PATH "Path to host ComputeCpp root folder whe cross-compiling")
 
-# Used for running executables on the host
-set(computecpp_host_find_hint ${computecpp_find_hint})
+set(computecpp_find_hint "${ComputeCpp_DIR}")
 
-if(CMAKE_CROSSCOMPILING)
-  # ComputeCpp_HOST_DIR is used to find executables that are run on the host
-  if(DEFINED ComputeCpp_HOST_DIR)
-    set(computecpp_host_find_hint ${ComputeCpp_HOST_DIR})
-  elseif(DEFINED ENV{COMPUTECPP_HOST_DIR})
-    set(computecpp_host_find_hint $ENV{COMPUTECPP_HOST_DIR})
-  endif()
+if(CMAKE_CROSSCOMPILING AND ComputeCpp_HOST_DIR)
+  # Used for running executables on the host
+  set(computecpp_host_find_hint "${ComputeCpp_HOST_DIR}")
+else()
+  set(computecpp_host_find_hint ${computecpp_find_hint})
 endif()
 
 find_program(ComputeCpp_DEVICE_COMPILER_EXECUTABLE compute++

--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -43,6 +43,8 @@ mark_as_advanced(COMPUTECPP_BITCODE)
 
 set(SYCL_LANGUAGE_VERSION "2017" CACHE STRING "SYCL version to use. Defaults to 1.2.1.")
 
+option(COMPUTECPP_INCLUDE_AFTER "Force integration header to be included after main" OFF)
+
 find_package(OpenCL REQUIRED)
 
 # Find ComputeCpp package
@@ -325,10 +327,6 @@ function(__build_ir)
     add_custom_target(${headerTargetName} DEPENDS ${outputDeviceFile} ${outputSyclFile})
     add_dependencies(${SDK_BUILD_IR_TARGET} ${headerTargetName})
   endif()
-  
-  if(COMPUTECPP_SDK_INCLUDE_AFTER)
-    set_property(TARGET ${SDK_ADD_SYCL_TARGET} PROPERTY COMPUTECPP_INCLUDE_AFTER 1)
-  endif()
 
   # This property can be set on a per-target basis to indicate that the
   # integration header should appear after the main source listing
@@ -411,6 +409,11 @@ function(add_sycl_to_target)
   )
 
   set_target_properties(${SDK_ADD_SYCL_TARGET} PROPERTIES LINKER_LANGUAGE CXX)
+
+  if(COMPUTECPP_INCLUDE_AFTER)
+    # Ensure all SYCL targets include the integration header after main
+    set_property(TARGET ${SDK_ADD_SYCL_TARGET} PROPERTY COMPUTECPP_INCLUDE_AFTER 1)
+  endif()
 
   # If the CXX compiler is set to compute++ enable the driver.
   get_filename_component(cmakeCxxCompilerFileName "${CMAKE_CXX_COMPILER}" NAME)

--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -328,6 +328,10 @@ function(__build_ir)
     add_custom_target(${headerTargetName} DEPENDS ${outputDeviceFile} ${outputSyclFile})
     add_dependencies(${SDK_BUILD_IR_TARGET} ${headerTargetName})
   endif()
+  
+  if(COMPUTECPP_SDK_INCLUDE_AFTER)
+    set_property(TARGET ${SDK_ADD_SYCL_TARGET} PROPERTY COMPUTECPP_INCLUDE_AFTER 1)
+  endif()
 
   # This property can be set on a per-target basis to indicate that the
   # integration header should appear after the main source listing


### PR DESCRIPTION
Added `COMPUTECPP_SDK_INCLUDE_AFTER` option
that affects all SYCL targets by setting the `COMPUTECPP_INCLUDE_AFTER` property.

The option is disabled by default for now.

Additional changes:
* Make ComputeCpp_DIR a cache variable
* Updated .gitignore