### PR TITLE
Add warning if no sources are passed to add_sycl_to_target

### DIFF
--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -399,10 +399,6 @@ function(add_sycl_to_target)
   set(one_value_args
     TARGET
   )
-  if (NOT SOURCES)
-    message(WARNING "No source files provided to add_sycl_to_target. "
-                    "SYCL integration headers may not be generated.")
-  endif()
   set(multi_value_args
     SOURCES
   )
@@ -412,7 +408,10 @@ function(add_sycl_to_target)
     "${multi_value_args}"
     ${ARGN}
   )
-
+  if ("${SDK_ADD_SYCL_SOURCES}" STREQUAL "")
+    message(WARNING "No source files provided to add_sycl_to_target. "
+                    "SYCL integration headers may not be generated.")
+  endif()
   set_target_properties(${SDK_ADD_SYCL_TARGET} PROPERTIES LINKER_LANGUAGE CXX)
 
   # If the CXX compiler is set to compute++ enable the driver.

--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -399,6 +399,10 @@ function(add_sycl_to_target)
   set(one_value_args
     TARGET
   )
+  if (NOT SOURCES)
+    message(WARNING "No source files provided to add_sycl_to_target. "
+                    "SYCL integration headers may not be generated.")
+  endif()
   set(multi_value_args
     SOURCES
   )


### PR DESCRIPTION
Ran into problems with this where I was using the host_selector for my cl::sycl::queue, no warnings or issues came up at first. Then switched to default_selector which triggered some strange SYCL exceptions. Turns out it was caused by the fact that CMake will not warn the user if a passed string is empty or undefined. I was passing an empty string to add_sycl_to_target which was causing no sycl integration headers to be generated. This small change will print the following warning into the console when running CMake if no sources are provided:
```
CMake Warning at cmake/FindComputeCpp.cmake:403 (message):
  No source files provided to add_sycl_to_target. SYCL integration 
  headers may not be generated.
Call Stack (most recent call first):
  CMakeLists.txt:63 (add_sycl_to_target)
  ```