### PR TITLE
Fix usage of constexpr constants in MSVC

### DIFF
--- a/samples/vector-addition-examples.cpp
+++ b/samples/vector-addition-examples.cpp
@@ -55,7 +55,7 @@ class VecAddKernelMasked;
 class VecAddKernelPredicated;
 
 void zeroBuffer(sycl::buffer<float, 1> b) {
-  constexpr auto dwrite = sycl::access::mode::discard_write;
+  static constexpr auto dwrite = sycl::access::mode::discard_write;
   auto h = b.get_access<dwrite>();
   for (auto i = 0u; i < b.get_range()[0]; i++) {
     h[i] = 0.f;
@@ -63,7 +63,7 @@ void zeroBuffer(sycl::buffer<float, 1> b) {
 }
 
 void sumBuffer(sycl::buffer<float, 1> b) {
-  constexpr auto read = sycl::access::mode::read;
+  static constexpr auto read = sycl::access::mode::read;
   auto h = b.get_access<read>();
   auto sum = 0.0f;
   for (auto i = 0u; i < b.get_range()[0]; i++) {
@@ -78,9 +78,9 @@ void sumBuffer(sycl::buffer<float, 1> b) {
  * The general flow is that the output buffer is zeroed, the calculation
  * scheduled, then the sum printed for each of the functions. */
 int main(int argc, char* argv[]) {
-  constexpr auto read = sycl::access::mode::read;
-  constexpr auto write = sycl::access::mode::write;
-  constexpr auto dwrite = sycl::access::mode::discard_write;
+  static constexpr auto read = sycl::access::mode::read;
+  static constexpr auto write = sycl::access::mode::write;
+  static constexpr auto dwrite = sycl::access::mode::discard_write;
   constexpr const size_t N = 100000;
   const sycl::range<1> VecSize{N};
 

--- a/samples/vector-addition-tiled.cpp
+++ b/samples/vector-addition-tiled.cpp
@@ -59,6 +59,7 @@ int main(int argc, char* argv[]) {
   static constexpr auto write = sycl::access::mode::write;
   static constexpr auto rw = sycl::access::mode::read_write;
   static constexpr auto dwrite = sycl::access::mode::discard_write;
+  using local_acc = sycl::accessor<float, 1, rw, sycl::access::target::local>;
   const sycl::range<1> VecSize{N};
   const sycl::range<1> TileSize{T};
 
@@ -87,10 +88,8 @@ int main(int argc, char* argv[]) {
       auto a = bufA.get_access<read>(h);
       auto b = bufB.get_access<read>(h);
       auto c = bufC.get_access<dwrite>(h);
-      sycl::accessor<float, 1, rw, sycl::access::target::local> tile1(TileSize,
-                                                                      h);
-      sycl::accessor<float, 1, rw, sycl::access::target::local> tile2(TileSize,
-                                                                      h);
+      local_acc tile1(TileSize, h);
+      local_acc tile2(TileSize, h);
 
       h.parallel_for<TiledVecAdd>(
           sycl::nd_range<1>(VecSize, TileSize), [=](sycl::nd_item<1> i) {
@@ -119,10 +118,8 @@ int main(int argc, char* argv[]) {
       auto a = bufA.get_access<read>(h);
       auto b = bufB.get_access<read>(h);
       auto c = bufC.get_access<write>(h);
-      sycl::accessor<float, 1, rw, sycl::access::target::local> tile1(TileSize,
-                                                                      h);
-      sycl::accessor<float, 1, rw, sycl::access::target::local> tile2(TileSize,
-                                                                      h);
+      local_acc tile1(TileSize, h);
+      local_acc tile2(TileSize, h);
 
       h.parallel_for<TiledVecAddDMA>(
           sycl::nd_range<1>(VecSize, TileSize), [=](sycl::nd_item<1> i) {

--- a/samples/vector-addition-tiled.cpp
+++ b/samples/vector-addition-tiled.cpp
@@ -55,10 +55,10 @@ class TiledVecAddDMA;
 int main(int argc, char* argv[]) {
   constexpr const size_t N = 128000;  // this is the total vector size
   constexpr const size_t T = 32;      // this is the tile size
-  constexpr auto read = sycl::access::mode::read;
-  constexpr auto write = sycl::access::mode::write;
-  constexpr auto rw = sycl::access::mode::read_write;
-  constexpr auto dwrite = sycl::access::mode::discard_write;
+  static constexpr auto read = sycl::access::mode::read;
+  static constexpr auto write = sycl::access::mode::write;
+  static constexpr auto rw = sycl::access::mode::read_write;
+  static constexpr auto dwrite = sycl::access::mode::discard_write;
   const sycl::range<1> VecSize{N};
   const sycl::range<1> TileSize{T};
 
@@ -84,7 +84,7 @@ int main(int argc, char* argv[]) {
 
   {
     auto cg = [&](sycl::handler& h) {
-      constexpr auto local = sycl::access::target::local;
+      static constexpr auto local = sycl::access::target::local;
 
       auto a = bufA.get_access<read>(h);
       auto b = bufB.get_access<read>(h);
@@ -116,7 +116,7 @@ int main(int argc, char* argv[]) {
 
   {
     auto cg = [&](sycl::handler& h) {
-      constexpr auto local = sycl::access::target::local;
+      static constexpr auto local = sycl::access::target::local;
 
       auto a = bufA.get_access<read>(h);
       auto b = bufB.get_access<read>(h);

--- a/samples/vector-addition-tiled.cpp
+++ b/samples/vector-addition-tiled.cpp
@@ -84,13 +84,13 @@ int main(int argc, char* argv[]) {
 
   {
     auto cg = [&](sycl::handler& h) {
-      static constexpr auto local = sycl::access::target::local;
-
       auto a = bufA.get_access<read>(h);
       auto b = bufB.get_access<read>(h);
       auto c = bufC.get_access<dwrite>(h);
-      sycl::accessor<float, 1, rw, local> tile1(TileSize, h);
-      sycl::accessor<float, 1, rw, local> tile2(TileSize, h);
+      sycl::accessor<float, 1, rw, sycl::access::target::local> tile1(TileSize,
+                                                                      h);
+      sycl::accessor<float, 1, rw, sycl::access::target::local> tile2(TileSize,
+                                                                      h);
 
       h.parallel_for<TiledVecAdd>(
           sycl::nd_range<1>(VecSize, TileSize), [=](sycl::nd_item<1> i) {
@@ -116,13 +116,13 @@ int main(int argc, char* argv[]) {
 
   {
     auto cg = [&](sycl::handler& h) {
-      static constexpr auto local = sycl::access::target::local;
-
       auto a = bufA.get_access<read>(h);
       auto b = bufB.get_access<read>(h);
       auto c = bufC.get_access<write>(h);
-      sycl::accessor<float, 1, rw, local> tile1(TileSize, h);
-      sycl::accessor<float, 1, rw, local> tile2(TileSize, h);
+      sycl::accessor<float, 1, rw, sycl::access::target::local> tile1(TileSize,
+                                                                      h);
+      sycl::accessor<float, 1, rw, sycl::access::target::local> tile2(TileSize,
+                                                                      h);
 
       h.parallel_for<TiledVecAddDMA>(
           sycl::nd_range<1>(VecSize, TileSize), [=](sycl::nd_item<1> i) {


### PR DESCRIPTION
Seemingly MSVC cannot consume the constexpr constants in the
lambda without them being static as well.