### PR TITLE
Fix INTERFACE->PUBLIC in compile definitions

### DIFF
--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -556,6 +556,6 @@ function(add_sycl_to_target)
     APPEND PROPERTY LINK_LIBRARIES ComputeCpp::ComputeCpp)
   set_property(TARGET ${ARG_TARGET}
     APPEND PROPERTY INTERFACE_LINK_LIBRARIES ComputeCpp::ComputeCpp)
-  target_compile_definitions(${ARG_TARGET} INTERFACE
+  target_compile_definitions(${ARG_TARGET} PUBLIC
     SYCL_LANGUAGE_VERSION=${SYCL_LANGUAGE_VERSION})
 endfunction(add_sycl_to_target)


### PR DESCRIPTION
Previously only targets which subsequently linked against targets
which had the SYCL version set as a compile definition would see
it. Now, since it is PUBLIC, all targets which link and the target
itself will see the definition of the language version.