### PR TITLE
Change virtual pointer to use vptr namespace instead of cl::sycl::codeplay namespace

### DIFF
--- a/include/vptr/README.md
+++ b/include/vptr/README.md
@@ -57,14 +57,14 @@ simultaneously.
 ## Usage
 
 Include the `virtual_ptr` header file in your program. Replace your
-device `malloc` and `free` operations with `codeplay::SYCLmalloc`
-and `codeplay::SYCLfree`. These functions are not thread-safe, even
+device `malloc` and `free` operations with `vptr::SYCLmalloc`
+and `vptr::SYCLfree`. These functions are not thread-safe, even
 though the underlying SYCL buffer objects are thread-safe.
 
 To retrieve the SYCL buffer from the virtual pointer, use the
-`codeplay::PointerMapper::get_buffer` function. The offset into the
+`vptr::PointerMapper::get_buffer` function. The offset into the
 SYCL buffer on the device side can be retrieved using the
-`codeplay::PointerMapper::get_offset` function. A pointer of size
+`vptr::PointerMapper::get_offset` function. A pointer of size
 zero can be malloc’ed and free’d but will throw an exception if
 accessed.
 

--- a/include/vptr/virtual_ptr.hpp
+++ b/include/vptr/virtual_ptr.hpp
@@ -35,11 +35,6 @@
 
 #include <CL/sycl.hpp>
 
-#ifdef SYCL_IMPLEMENTATION_ONEAPI
-#if __SYCL_COMPILER_VERSION >= 20220812
-#define NO_CL_NAMESPACE
-#endif
-#endif
 
 #include <cstddef>
 #include <queue>
@@ -47,11 +42,7 @@
 #include <stdexcept>
 #include <map>
 
-#ifndef NO_CL_NAMESPACE
-namespace cl {
-#endif
-namespace sycl {
-namespace codeplay {
+namespace vptr {
 
 using sycl_acc_target = cl::sycl::access::target;
 using sycl_acc_mode = cl::sycl::access::mode;
@@ -514,7 +505,7 @@ inline void PointerMapper::remove_pointer<false>(const virtual_pointer_t ptr) {
  * \throw cl::sycl::exception if error while creating the buffer
  */
 inline void* SYCLmalloc(size_t size, PointerMapper& pMap,
-                        const property_list& pList = {}) {
+                        const cl::sycl::property_list& pList = {}) {
   if (size == 0) {
     return nullptr;
   }
@@ -546,12 +537,6 @@ inline void SYCLfreeAll(PointerMapper& pMap) {
   pMap.clear();
 }
 
-}  // namespace codeplay
-}  // namespace sycl
-#ifndef NO_CL_NAMESPACE
-}  // namespace cl
-#else
-#undef NO_CL_NAMESPACE
-#endif
+}  // namespace vptr
 
 #endif  // CL_SYCL_SDK_CODEPLAY_VIRTUAL_PTR_HPP

--- a/include/vptr/virtual_ptr.hpp
+++ b/include/vptr/virtual_ptr.hpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *  Copyright (C) 2017 Codeplay Software Limited
+ *  Copyright (C) Codeplay Software Limited
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -35,13 +35,21 @@
 
 #include <CL/sycl.hpp>
 
+#ifdef SYCL_IMPLEMENTATION_ONEAPI
+#if __SYCL_COMPILER_VERSION >= 20220812
+#define NO_CL_NAMESPACE
+#endif
+#endif
+
 #include <cstddef>
 #include <queue>
 #include <set>
 #include <stdexcept>
 #include <map>
 
+#ifndef NO_CL_NAMESPACE
 namespace cl {
+#endif
 namespace sycl {
 namespace codeplay {
 
@@ -540,5 +548,10 @@ inline void SYCLfreeAll(PointerMapper& pMap) {
 
 }  // namespace codeplay
 }  // namespace sycl
+#ifndef NO_CL_NAMESPACE
 }  // namespace cl
+#else
+#undef NO_CL_NAMESPACE
+#endif
+
 #endif  // CL_SYCL_SDK_CODEPLAY_VIRTUAL_PTR_HPP

--- a/samples/vptr.cpp
+++ b/samples/vptr.cpp
@@ -50,7 +50,7 @@ const size_t M = 150;
 int main() {
   {
     queue myQueue;
-    cl::sycl::codeplay::PointerMapper pMap;
+    vptr::PointerMapper pMap;
 
     /* Allocate the matrices using SYCLmalloc. a, b and c are virtual pointers,
      * pointing to device buffers.

--- a/tests/vptr/accessor.cc
+++ b/tests/vptr/accessor.cc
@@ -39,7 +39,7 @@ const sycl_acc_target sycl_acc_host = sycl_acc_target::host_buffer;
 using sycl_acc_mode = cl::sycl::access::mode;
 const sycl_acc_mode sycl_acc_rw = sycl_acc_mode::read_write;
 
-using namespace cl::sycl::codeplay;
+using namespace vptr;
 
 TEST(accessor, basic_test) {
   PointerMapper pMap;

--- a/tests/vptr/basic.cc
+++ b/tests/vptr/basic.cc
@@ -40,7 +40,7 @@ const sycl_acc_mode sycl_acc_rw = sycl_acc_mode::read_write;
 using sycl_acc_target = cl::sycl::access::target;
 const sycl_acc_target sycl_acc_host = sycl_acc_target::host_buffer;
 
-using namespace cl::sycl::codeplay;
+using namespace vptr;
 
 TEST(pointer_mapper, basic_test) {
   PointerMapper pMap;

--- a/tests/vptr/offset.cc
+++ b/tests/vptr/offset.cc
@@ -39,7 +39,7 @@ const sycl_acc_target sycl_acc_buffer = sycl_acc_target::global_buffer;
 using sycl_acc_mode = cl::sycl::access::mode;
 const sycl_acc_mode sycl_acc_rw = sycl_acc_mode::read_write;
 
-using namespace cl::sycl::codeplay;
+using namespace vptr;
 
 using buffer_t = PointerMapper::buffer_t;
 

--- a/tests/vptr/space.cc
+++ b/tests/vptr/space.cc
@@ -33,7 +33,7 @@
 #include "vptr/pointer_alias.hpp"
 #include "vptr/virtual_ptr.hpp"
 
-using namespace cl::sycl::codeplay;
+using namespace vptr;
 
 using buffer_t = PointerMapper::buffer_t;
 


### PR DESCRIPTION
The vptr class is used in SYCL-BLAS. We want to be able to compile SYCL-BLAS using DPC++. The latest DPC++ nightlies generates errors due to the cl::sycl namespace used for virtual pointers. To avoid this issue, this patch uses the SYCL-2020 ::sycl namespace for DPC++.