### PR TITLE
Update vector sample to reflect better practice

### DIFF
--- a/samples/simple-example-of-vectors.cpp
+++ b/samples/simple-example-of-vectors.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *
- *  Copyright (C) 2016 Codeplay Software Limited
+ *  Copyright (C) Codeplay Software Limited
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -33,21 +33,16 @@ using namespace cl::sycl;
 
 class vector_example;
 
-int ret = 0;
-
 /* The purpose of this sample code is to demonstrate
  * the usage of vectors inside SYCL kernels. */
 int main() {
+  int ret = 0;
   const int size = 64;
-  cl::sycl::cl_float4 dataA[size];
-  cl::sycl::cl_float3 dataB[size];
+  cl::sycl::float4 dataA[size];
+  cl::sycl::float3 dataB[size];
 
-  /* Here, the vectors are initialised. cl_float4 is a short name for
-   * cl::sycl::vec<float, 4> - the other short names are similar.
-   * When describing data types that will be shared between host and
-   * device (as in this situation), the interop types (starting with
-   * cl_) *must* be used. Not using them could lead to silent data
-   * corruption. */
+  /* Here, the vectors are initialised. float4 is a short name for
+   * cl::sycl::vec<float, 4> - the other short names are similar. */
   for (int i = 0; i < size; i++) {
     dataA[i] = float4(2.0f, 1.0f, 1.0f, static_cast<float>(i));
     dataB[i] = float3(0.0f, 0.0f, 0.0f);
@@ -56,8 +51,8 @@ int main() {
   {
     /* In previous samples, we've mostly seen scalar types, though it is
      * perfectly possible to pass vectors to buffers. */
-    buffer<cl::sycl::cl_float4, 1> bufA(dataA, range<1>(size));
-    buffer<cl::sycl::cl_float3, 1> bufB(dataB, range<1>(size));
+    buffer<cl::sycl::float4, 1> bufA(dataA, range<1>(size));
+    buffer<cl::sycl::float3, 1> bufB(dataB, range<1>(size));
 
     queue myQueue;
 
@@ -66,9 +61,6 @@ int main() {
       auto ptrB = bufB.get_access<access::mode::read_write>(cgh);
 
       /* This kernel demonstrates the following:
-       *   It is possible to use auto to describe the type of the return
-       *   value from accessor::operator[]()
-       *
        *   You can access the individual elements of a vector by using the
        *   functions x(), y(), z(), w() and so on, as described in the spec
        *
@@ -80,9 +72,9 @@ int main() {
        *   Vectors can also be scaled easily using operator overloads */
       cgh.parallel_for<vector_example>(range<3>(4, 4, 4), [=](item<3> item) {
         auto in = ptrA[item.get_linear_id()];
-        float w = in.w();
-        float3 swizzle = in.xyz();
-        float3 scaled = swizzle * w;
+        auto w = in.w();
+        vec<float,3> swizzle = in.xyz();
+        auto scaled = swizzle * w;
         ptrB[item.get_linear_id()] = scaled;
       });
     });


### PR DESCRIPTION
Some misleading comments were removed, and types names updated to match the 2020 specification.